### PR TITLE
Set GLib program name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,13 @@ fn run() -> Result<(), Error> {
         Server::new(&format!("0.0.0.0:{}", puffin_http::DEFAULT_PORT)).unwrap()
     };
 
+    // Set GLib application name.
+    //
+    // This is necessary to match the flatpak ID when run inside flatpak due to
+    // WebKit's internal flatpak sandbox handling, which is why the reverse
+    // domain name notation is used.
+    glib::set_prgname(Some("org.catacombing.kumo"));
+
     let queue = Queue::new()?;
     let main_loop = MainLoop::new(None, true);
     let mut state = State::new(queue.local_handle(), main_loop.clone())?;

--- a/src/window.rs
+++ b/src/window.rs
@@ -238,7 +238,7 @@ impl Window {
         let decorations = WindowDecorations::RequestServer;
         let xdg = protocol_states.xdg_shell.create_window(surface, decorations, &wayland_queue);
         xdg.set_title("Kumo");
-        xdg.set_app_id("Kumo");
+        xdg.set_app_id("org.catacombing.kumo");
         xdg.commit();
 
         // Resize UI elements to the initial window size.


### PR DESCRIPTION
This patch should work around issues with packaging Kumo in flathub by setting the GLib program name to something that matches WebKit's internal expectations.

The Wayland App ID is also updated to use the reverse domain name notation, since we do control the catacombing.org domain now.