### PR TITLE
Add Servo browser engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Dependencies
+        run: |
+          sudo apt update
+          sudo apt install \
+            clang \
+            libfontconfig-dev \
+            libglib2.0-dev \
+            libpango1.0-dev \
+            libxkbcommon-dev \
+            llvm-dev
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Stable Servo
+        run: cargo test --no-default-features --features servo
+      - name: Oldstable Servo
+        run: |
+          oldstable=$(cat Cargo.toml | grep "rust-version =" | sed 's/.*"\(.*\)".*/\1/')
+          rustup toolchain install --profile minimal $oldstable
+          rustup default $oldstable
+          cargo test --no-default-features --features servo
+      - name: Clippy Servo
+        run: |
+          rustup component add clippy
+          cargo clippy --no-default-features --features servo -- -D warnings
+      - name: Rustfmt
+        run: |
+          rustup toolchain install nightly -c rustfmt
+          cargo +nightly fmt -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,96 @@
 version = 4
 
 [[package]]
+name = "accesskit"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5351dcebb14b579ccab05f288596b2ae097005be7ee50a7c3d4ca9d0d5a66f6a"
+dependencies = [
+ "enumn",
+ "serde",
+ "uuid",
+]
+
+[[package]]
+name = "accountable-refcell"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afea9052e0b2d90e38572691d87194b2e5d8d6899b9b850b22aaab17e486252"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "aes-kw"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
+dependencies = [
+ "aes",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -15,6 +101,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -33,7 +161,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -43,15 +186,24 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -78,9 +230,19 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "app_units"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467b60e4ee6761cd6fd4e03ea58acefc8eec0d1b1def995c1b3b783fa7be8a60"
+dependencies = [
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "approx"
@@ -92,10 +254,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-tungstenite"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb26fbd2a93308b1c1b74ac4e494a11ac10db57c476882240573bdf961463520"
+dependencies = [
+ "atomic-waker",
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atomic_refcell"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
 
 [[package]]
 name = "autocfg"
@@ -104,10 +385,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.15.2"
+name = "av-scenechange"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -115,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.35.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",
@@ -126,10 +450,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -163,6 +526,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,9 +557,30 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+dependencies = [
+ "core2",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block"
@@ -181,16 +589,93 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
-name = "bumpalo"
-version = "3.19.1"
+name = "block-buffer"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "buf-read-ext"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e2c71c44e5bbc64de4ecfac946e05f9bba5cc296ea7bab4d3eda242a3ffa73c"
+
+[[package]]
+name = "build-parallel"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e3ff9db740167616e528c509b3618046fc05d337f8f3182d300f4aa977d2bb"
+dependencies = [
+ "crossbeam-utils",
+ "jobserver",
+ "num_cpus",
+]
+
+[[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -203,7 +688,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -220,9 +705,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cairo-rs"
@@ -230,7 +715,7 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b01fe135c0bd16afe262b6dea349bd5ea30e6de50708cec639aae7c5c14cc7e4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -248,16 +733,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "calendrical_calculations"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97f73e95d668625c9b28a3072e6326773785a0cf807de9f3d632778438f3d38"
+dependencies = [
+ "core_maths",
+ "displaydoc",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "cc"
-version = "1.2.51"
+name = "cbc"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -277,14 +781,14 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.5"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21be0e1ce6cdb2ee7fff840f922fb04ead349e5cfb1e750b769132d44ce04720"
+checksum = "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -312,16 +816,63 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono"
-version = "0.4.42"
+name = "chacha20"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -337,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -347,11 +898,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -359,21 +910,30 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "cmake"
@@ -385,6 +945,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "color"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18ef4657441fb193b65f34dc39b3781f0dfec23d3bd94d0eeb4e88cde421edb"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,9 +970,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -407,10 +985,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "configory"
-version = "0.6.2"
+name = "compression-codecs"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617d9350a98f156791d1f6e25aceeba5ae45418f22d553429248eaeb6b97b264"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
+name = "configory"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78489243d7dbac060ae59dd9ca2ddf36f69005ddd542f89ecaae5a0d39814ec3"
 dependencies = [
  "configory_derive",
  "dirs",
@@ -419,19 +1017,71 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml",
 ]
 
 [[package]]
 name = "configory_derive"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f81505e79b358115ada50fa8bcfb981a0f61c0b37c5c442ace16c9dd0b06f81"
+checksum = "70a0d8799bda333c976d37fb47b6b30ca24e4f9b2e24193727b5b5b0b47f232c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "content-security-policy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d348c3856ad6a6b957d69dc8cf93e66fe9be5a7657fdd7028b1a56d2775e3fce"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "serde",
+ "sha2",
+ "url",
+]
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -449,6 +1099,69 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "libc",
+]
+
+[[package]]
+name = "core-text"
+version = "20.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
+dependencies = [
+ "core-foundation 0.9.4",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -494,6 +1207,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,7 +1244,21 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.11.3",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "serde",
  "smallvec",
 ]
 
@@ -512,7 +1268,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eeef9ae8c0e112edd89eb6406b3156ffa99c7e037b3baef1dbdf4158d35c324"
 dependencies = [
- "cssparser",
+ "cssparser 0.35.0",
 ]
 
 [[package]]
@@ -522,7 +1278,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -530,6 +1295,66 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "dashmap"
@@ -546,10 +1371,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "der_derive",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
 
 [[package]]
 name = "derive_more"
@@ -569,7 +1433,52 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.112",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "diplomat"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3137c640d2bac491dbfca7f9945c948f888dd8c95bdf7ee6b164fbdfa5d3efc2"
+dependencies = [
+ "diplomat_core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "diplomat-runtime"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53bfcc833b58615b593a6e5c46771cb36b1cfce94899c60823810939fe8ca9d9"
+
+[[package]]
+name = "diplomat_core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7aca1d8f9e7b73ad61785beedc9556ad79f84b15c15abaa7041377e42284c1"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "smallvec",
+ "strck_ident",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -595,11 +1504,11 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
 ]
 
@@ -611,14 +1520,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "dlib"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading",
 ]
@@ -630,27 +1539,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
-name = "drm"
-version = "0.14.1"
+name = "dpi"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "drm"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b71449a23fe79542d6527ca572844b2016abf9573c49e43144d546b1735aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
+ "bytemuck_derive",
  "drm-ffi",
  "drm-fourcc",
  "libc",
- "rustix 0.38.44",
+ "rustix 1.1.4",
 ]
 
 [[package]]
 name = "drm-ffi"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e41459d99a9b529845f6d2c909eb9adf3b6d2f82635ae40be8de0601726e8b"
+checksum = "51a91c9b32ac4e8105dec255e849e0d66e27d7c34d184364fb93e469db08f690"
 dependencies = [
  "drm-sys",
- "rustix 0.38.44",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -661,12 +1577,12 @@ checksum = "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4"
 
 [[package]]
 name = "drm-sys"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafb66c8dbc944d69e15cfcc661df7e703beffbaec8bd63151368b06c5f9858c"
+checksum = "ecc8e1361066d91f5ffccff060a3c3be9c3ecde15be2959c1937595f7a82a9f8"
 dependencies = [
  "libc",
- "linux-raw-sys 0.6.5",
+ "linux-raw-sys 0.9.4",
 ]
 
 [[package]]
@@ -691,10 +1607,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dwrote"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b35532432acc8b19ceed096e35dfa088d3ea037fe4f3c085f1f97f33b4d02"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "serde",
+ "serde_derive",
+ "winapi",
+ "wio",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encoding_c"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af727805f3b0d79956bde5b35732669fb5c5d45a94893798e7b7e70cfbf9cc1"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
+name = "encoding_c_mem"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a80a16821fe8c7cab96e0c67b57cd7090e021e9615e6ce6ab0cf866c44ed1f0"
+dependencies = [
+ "encoding_rs",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -703,6 +1698,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+ "serde",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "env_filter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+dependencies = [
+ "anstream 0.6.21",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -719,6 +1769,48 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "etagere"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc89bf99e5dc15954a60f707c1e09d7540e5cd9af85fa75caa0b510bc08c5342"
+dependencies = [
+ "euclid",
+ "serde",
+ "svg_fmt",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
 ]
 
 [[package]]
@@ -740,6 +1832,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,20 +1861,79 @@ dependencies = [
 ]
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.6"
+name = "fearless_simd"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+checksum = "8fb2907d1f08b2b316b9223ced5b0e89d87028ba8deae9764741dba8ff7f3903"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed_decimal"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0febbeb1118a9ecdee6e4520ead6b54882e843dd0592ad233247dbee84c53db8"
+dependencies = [
+ "displaydoc",
+ "smallvec",
+ "writeable 0.5.5",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "float-cmp"
@@ -774,10 +1945,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
+
+[[package]]
+name = "fontsan"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52fd401b496627c46f35318272508fcdcb77927868507ed2ad796408aa903923"
+dependencies = [
+ "cc",
+ "fontsan-woff2",
+ "glob",
+ "libc",
+ "libz-sys",
+]
+
+[[package]]
+name = "fontsan-woff2"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106ebe29445505f3860765d2597ddad20a3e90174d6e8539a10d58253b3e5c0f"
+dependencies = [
+ "brotli-decompressor",
+ "cc",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -786,6 +2051,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "freetype"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a440748e063798e4893ceb877151e84acef9bea9a8c6800645cf3f1b3a7806e"
+dependencies = [
+ "freetype-sys",
+ "libc",
+]
+
+[[package]]
+name = "freetype-sys"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -804,11 +2090,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
+
+[[package]]
 name = "funq"
 version = "0.1.0"
 dependencies = [
  "funq_derive",
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -817,7 +2109,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -831,10 +2123,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.31"
+name = "futures"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -842,15 +2148,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -859,47 +2165,44 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -913,16 +2216,56 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.16"
+name = "gaol"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "061957ca7a966a39a79ebca393a9a6c7babda10bf9dd6f11d00041558d929c22"
+dependencies = [
+ "libc",
+ "log",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
- "wasi",
- "wasm-bindgen",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -932,11 +2275,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -948,6 +2322,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gio"
@@ -991,12 +2371,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "gleam"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8647cc2e2ffde598ce5ca2809452e722dd8dc127885ab8aba2fa8b469cd3ed94"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
 name = "glib"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1017,11 +2406,11 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf59b675301228a696fe01c3073974643365080a76cc3ed5bc2cbc466ad87f17"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1041,12 +2430,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glslopt"
+version = "0.1.12"
+source = "git+https://github.com/chrisduerr/glslopt-rs?rev=c3c9457b752729f90761352e6c1e70e051430dd6#c3c9457b752729f90761352e6c1e70e051430dd6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "glutin"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg_aliases",
  "cgl",
  "dispatch2",
@@ -1083,6 +2492,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "grid"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "harfbuzz-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb86e2fef3ba40cebffb8fa2cba811f06aa5c5fd296a4e469473e5398d166594"
+dependencies = [
+ "cc",
+ "core-graphics",
+ "core-text",
+ "foreign-types",
+ "freetype-sys",
+ "pkg-config",
+ "winapi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,21 +2580,94 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash",
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.11.0"
+name = "hashbrown"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core 0.2.0",
+ "http 0.2.12",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core 0.3.0",
+ "http 1.4.0",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http 0.2.12",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.4.0",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1113,12 +2676,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "home"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -1133,12 +2741,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1149,8 +2768,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1161,21 +2780,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "hyper"
-version = "1.8.1"
+name = "httpdate"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1187,35 +2854,36 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.9.0",
  "hyper-util",
+ "log",
  "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1223,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1233,7 +2901,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1246,6 +2914,118 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_calendar"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7265b2137f9a36f7634a308d91f984574bbdba8cfd95ceffe1c345552275a8ff"
+dependencies = [
+ "calendrical_calculations",
+ "displaydoc",
+ "icu_calendar_data",
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_calendar_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "820499e77e852162190608b4f444e7b4552619150eafc39a9e39333d9efae9e1"
+
+[[package]]
+name = "icu_capi"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acc33c4f501b515cdb6b583b31ec009479a4c0cb4cf28dcdfcd54b29069d725e"
+dependencies = [
+ "diplomat",
+ "diplomat-runtime",
+ "icu_calendar",
+ "icu_casemap",
+ "icu_collator",
+ "icu_collections 1.5.0",
+ "icu_datetime",
+ "icu_decimal",
+ "icu_experimental",
+ "icu_list",
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_normalizer 1.5.0",
+ "icu_plurals",
+ "icu_properties 1.5.1",
+ "icu_provider 1.5.0",
+ "icu_provider_adapters",
+ "icu_segmenter 1.5.0",
+ "icu_timezone",
+ "tinystr 0.7.6",
+ "unicode-bidi",
+ "writeable 0.5.5",
+]
+
+[[package]]
+name = "icu_casemap"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff0c8ae9f8d31b12e27fc385ff9ab1f3cd9b17417c665c49e4ec958c37da75f"
+dependencies = [
+ "displaydoc",
+ "icu_casemap_data",
+ "icu_collections 1.5.0",
+ "icu_locid",
+ "icu_properties 1.5.1",
+ "icu_provider 1.5.0",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_casemap_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd9f6276270c85a5cd54611adbbf94e993ec464a2a86a452a6c565b7ded5d9"
+
+[[package]]
+name = "icu_collator"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d370371887d31d56f361c3eaa15743e54f13bc677059c9191c77e099ed6966b2"
+dependencies = [
+ "displaydoc",
+ "icu_collator_data",
+ "icu_collections 1.5.0",
+ "icu_locid_transform",
+ "icu_normalizer 1.5.0",
+ "icu_properties 1.5.1",
+ "icu_provider 1.5.0",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_collator_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b353986d77d28991eca4dea5ef2b8982f639342ae19ca81edc44f048bc38ebb"
+
+[[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke 0.7.5",
+ "zerofrom",
+ "zerovec 0.10.4",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,9 +3033,129 @@ checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "yoke",
+ "yoke 0.8.1",
  "zerofrom",
- "zerovec",
+ "zerovec 0.11.5",
+]
+
+[[package]]
+name = "icu_datetime"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d115efb85e08df3fd77e77f52e7e087545a783fffba8be80bfa2102f306b1780"
+dependencies = [
+ "displaydoc",
+ "either",
+ "fixed_decimal",
+ "icu_calendar",
+ "icu_datetime_data",
+ "icu_decimal",
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_plurals",
+ "icu_provider 1.5.0",
+ "icu_timezone",
+ "smallvec",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_datetime_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef5f04076123cab1b7a926a7083db27fe0d7a0e575adb984854aae3f3a6507d"
+
+[[package]]
+name = "icu_decimal"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8fd98f86ec0448d85e1edf8884e4e318bb2e121bd733ec929a05c0a5e8b0eb"
+dependencies = [
+ "displaydoc",
+ "fixed_decimal",
+ "icu_decimal_data",
+ "icu_locid_transform",
+ "icu_provider 1.5.0",
+ "writeable 0.5.5",
+]
+
+[[package]]
+name = "icu_decimal_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c95dd97f5ccf6d837a9c115496ec7d36646fa86ca18e7f1412115b4c820ae2"
+
+[[package]]
+name = "icu_experimental"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "844ad7b682a165c758065d694bc4d74ac67f176da1c499a04d85d492c0f193b7"
+dependencies = [
+ "displaydoc",
+ "fixed_decimal",
+ "icu_collections 1.5.0",
+ "icu_decimal",
+ "icu_experimental_data",
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_normalizer 1.5.0",
+ "icu_pattern",
+ "icu_plurals",
+ "icu_properties 1.5.1",
+ "icu_provider 1.5.0",
+ "litemap 0.7.5",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "smallvec",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerofrom",
+ "zerotrie 0.1.3",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_experimental_data"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121df92eafb8f5286d4e8ff401c1e7db8384377f806db3f8db77b91e5b7bd4dd"
+
+[[package]]
+name = "icu_list"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfeda1d7775b6548edd4e8b7562304a559a91ed56ab56e18961a053f367c365"
+dependencies = [
+ "displaydoc",
+ "icu_list_data",
+ "icu_locid_transform",
+ "icu_provider 1.5.0",
+ "regex-automata 0.2.0",
+ "writeable 0.5.5",
+]
+
+[[package]]
+name = "icu_list_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b1a7fbdbf3958f1be8354cb59ac73f165b7b7082d447ff2090355c9a069120"
+
+[[package]]
+name = "icu_locale"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532b11722e350ab6bf916ba6eb0efe3ee54b932666afec989465f9243fe6dd60"
+dependencies = [
+ "icu_collections 2.1.1",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider 2.1.1",
+ "potential_utf",
+ "tinystr 0.8.2",
+ "zerovec 0.11.5",
 ]
 
 [[package]]
@@ -1265,10 +3165,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
+ "litemap 0.8.1",
+ "serde",
+ "tinystr 0.8.2",
+ "writeable 0.6.2",
+ "zerovec 0.11.5",
+]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c5f1d16b4c3a2642d3a719f18f6b06070ab0aef246a6418130c955ae08aa831"
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap 0.7.5",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections 1.5.0",
+ "icu_normalizer_data 1.5.1",
+ "icu_properties 1.5.1",
+ "icu_provider 1.5.0",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1277,13 +3235,19 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
+ "icu_collections 2.1.1",
+ "icu_normalizer_data 2.1.1",
+ "icu_properties 2.1.2",
+ "icu_provider 2.1.1",
  "smallvec",
- "zerovec",
+ "zerovec 0.11.5",
 ]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_normalizer_data"
@@ -1292,18 +3256,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
+name = "icu_pattern"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f36aafd098d6717de34e668a8120822275c1fba22b936e757b7de8a2fd7e4"
+dependencies = [
+ "displaydoc",
+ "either",
+ "writeable 0.5.5",
+ "yoke 0.7.5",
+ "zerofrom",
+]
+
+[[package]]
+name = "icu_plurals"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a70e7c025dbd5c501b0a5c188cd11666a424f0dadcd4f0a95b7dafde3b114"
+dependencies = [
+ "displaydoc",
+ "fixed_decimal",
+ "icu_locid_transform",
+ "icu_plurals_data",
+ "icu_provider 1.5.0",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_plurals_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a483403238cb7d6a876a77a5f8191780336d80fe7b8b00bfdeb20be6abbfd112"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections 1.5.0",
+ "icu_locid_transform",
+ "icu_properties_data 1.5.1",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "unicode-bidi",
+ "zerovec 0.10.4",
+]
+
+[[package]]
 name = "icu_properties"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "icu_collections",
+ "icu_collections 2.1.1",
  "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
+ "icu_properties_data 2.1.2",
+ "icu_provider 2.1.1",
+ "zerotrie 0.2.3",
+ "zerovec 0.11.5",
 ]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_properties_data"
@@ -1313,18 +3332,138 @@ checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "yoke 0.7.5",
+ "zerofrom",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_provider"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "writeable",
- "yoke",
+ "serde",
+ "stable_deref_trait",
+ "writeable 0.6.2",
+ "yoke 0.8.1",
  "zerofrom",
- "zerotrie",
- "zerovec",
+ "zerotrie 0.2.3",
+ "zerovec 0.11.5",
 ]
+
+[[package]]
+name = "icu_provider_adapters"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6324dfd08348a8e0374a447ebd334044d766b1839bb8d5ccf2482a99a77c0bc"
+dependencies = [
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "icu_segmenter"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a717725612346ffc2d7b42c94b820db6908048f39434504cb130e8b46256b0de"
+dependencies = [
+ "core_maths",
+ "displaydoc",
+ "icu_collections 1.5.0",
+ "icu_locid",
+ "icu_provider 1.5.0",
+ "icu_segmenter_data 1.5.1",
+ "utf8_iter",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a807a7488f3f758629ae86d99d9d30dce24da2fb2945d74c80a4f4a62c71db73"
+dependencies = [
+ "core_maths",
+ "icu_collections 2.1.1",
+ "icu_locale",
+ "icu_provider 2.1.1",
+ "icu_segmenter_data 2.1.1",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec 0.11.5",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e52775179941363cc594e49ce99284d13d6948928d8e72c755f55e98caa1eb"
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebbb7321d9e21d25f5660366cb6c08201d0175898a3a6f7a41ee9685af21c80"
+
+[[package]]
+name = "icu_timezone"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa91ba6a585939a020c787235daa8aee856d9bceebd6355e283c0c310bc6de96"
+dependencies = [
+ "displaydoc",
+ "icu_calendar",
+ "icu_provider 1.5.0",
+ "icu_timezone_data",
+ "tinystr 0.7.6",
+ "zerotrie 0.1.3",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_timezone_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adcf7b613a268af025bc2a2532b4b9ee294e6051c5c0832d8bff20ac0232e68"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1343,8 +3482,8 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
+ "icu_normalizer 2.1.1",
+ "icu_properties 2.1.2",
 ]
 
 [[package]]
@@ -1356,13 +3495,18 @@ dependencies = [
  "bytemuck",
  "byteorder-lite",
  "color_quant",
- "gif",
+ "exr",
+ "gif 0.14.1",
  "image-webp",
  "moxcms",
  "num-traits",
- "png",
- "zune-core",
- "zune-jpeg",
+ "png 0.18.1",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core 0.5.1",
+ "zune-jpeg 0.5.13",
 ]
 
 [[package]]
@@ -1376,22 +3520,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.12.1"
+name = "imagesize"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+
+[[package]]
+name = "imsz"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396dda16a82727ec2d14aabc1167832bb823d849c54a246ca0cff6cfb7bc697c"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "inherent"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "inotify-sys",
  "libc",
 ]
@@ -1406,20 +3581,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.11.0"
+name = "inout"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
 
 [[package]]
-name = "iri-string"
-version = "0.7.10"
+name = "interpolate_name"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
- "memchr",
- "serde",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "ipc-channel"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a441490012d80e9aea75fb27503df8e87e9557dcfc6fe4244dde86bfc12e94e3"
+dependencies = [
+ "crossbeam-channel",
+ "libc",
+ "mio",
+ "postcard",
+ "rand 0.9.2",
+ "rustc-hash 2.1.2",
+ "serde_core",
+ "tempfile",
+ "thiserror 2.0.18",
+ "uuid",
+ "windows",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1438,6 +3652,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1450,6 +3673,30 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jni"
@@ -1485,12 +3732,41 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
+dependencies = [
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
+name = "keyboard-types"
+version = "0.8.3"
+source = "git+https://github.com/chrisduerr/keyboard-types?rev=03b47d33d345b35671076bcd8ce4533250997c72#03b47d33d345b35671076bcd8ce4533250997c72"
+dependencies = [
+ "bitflags 2.11.0",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1523,39 +3799,69 @@ dependencies = [
 name = "kumo"
 version = "1.6.2"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "chrono",
  "clap",
  "configory",
  "dashmap",
  "dirs",
+ "dpi",
  "drm",
+ "euclid",
  "funq",
  "gio",
  "gl_generator",
  "glib",
  "glutin",
  "indexmap",
+ "keyboard-types",
  "libc",
  "librsvg",
  "pangocairo",
  "profiling",
  "puffin_http",
  "raw-window-handle",
- "reqwest",
  "rusqlite",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "serde",
+ "servo",
  "smallvec",
  "smithay-client-toolkit",
- "thiserror 2.0.17",
+ "surfman",
+ "tempfile",
+ "thiserror 2.0.18",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "wayland-backend",
  "wpe-platform",
  "wpe-webkit",
+ "xkbcommon-dl",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -1569,6 +3875,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -1577,10 +3886,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "libc"
-version = "0.2.178"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libloading"
@@ -1589,32 +3920,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.12"
+name = "libm"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
 name = "librsvg"
-version = "2.61.3"
+version = "2.61.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b612e3a9ec82c8ae9f2ebc9b2e8ff50aa831742686c0071998f76896cf214f"
+checksum = "14b9be8dd68c76a9a7d131534d80f9e526af5fc9f42ef43d9fca9605ca123065"
 dependencies = [
  "cairo-rs",
  "cast",
- "cssparser",
+ "cssparser 0.35.0",
  "cssparser-color",
  "data-url",
  "encoding_rs",
- "float-cmp",
+ "float-cmp 0.10.0",
  "gio",
  "glib",
  "image",
@@ -1622,7 +3961,7 @@ dependencies = [
  "language-tags",
  "libc",
  "locale_config",
- "markup5ever",
+ "markup5ever 0.35.0",
  "nalgebra",
  "num-traits",
  "pango",
@@ -1632,20 +3971,21 @@ dependencies = [
  "rctree",
  "regex",
  "rgb",
- "selectors",
+ "selectors 0.31.0",
  "string_cache 0.9.0",
  "system-deps",
  "tinyvec",
  "url",
- "xml5ever",
+ "xml5ever 0.35.0",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.36.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1658,6 +3998,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,15 +4023,21 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.6.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a385b1be4e5c3e362ad2ffa73c392e53f031eaa5b7d648e64cd87f27f6063d7"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litemap"
@@ -1701,6 +4065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
+ "serde",
 ]
 
 [[package]]
@@ -1710,22 +4075,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
+name = "loop9"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "malloc_buf"
@@ -1737,14 +4120,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_size_of_derive"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44db74bde26fdf427af23f1d146c211aed857c59e3be750cf2617f6b0b05c94"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
 dependencies = [
  "log",
- "tendril",
- "web_atoms",
+ "tendril 0.4.3",
+ "web_atoms 0.1.3",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril 0.5.0",
+ "web_atoms 0.2.3",
 ]
 
 [[package]]
@@ -1753,7 +4158,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.4.14",
 ]
 
 [[package]]
@@ -1767,18 +4172,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.7.6"
+name = "maybe-rayon"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime-multipart-hyper1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc819448803ee517eb413276ca59613c2850a95c4fdcd87ec82c5a6ce6cdab1a"
+dependencies = [
+ "buf-read-ext",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "mime",
+ "tempfile",
+ "textnonce",
+]
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -1805,8 +4251,35 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-dsa"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac4a46643af2001eafebcc37031fc459eb72d45057aac5d7a15b00046a2ad6db"
+dependencies = [
+ "const-oid",
+ "hybrid-array 0.3.1",
+ "num-traits",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha3",
+ "signature",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de49b3df74c35498c0232031bb7e85f9389f913e2796169c8ab47a53993a18f"
+dependencies = [
+ "hybrid-array 0.2.3",
+ "kem",
+ "rand_core 0.6.4",
+ "sha3",
 ]
 
 [[package]]
@@ -1820,6 +4293,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "mozangle"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298bc7f83d5cca3789e47779e92cda492b75f11e03995bf558475bd9df2f639b"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "walkdir",
+]
+
+[[package]]
+name = "mozjs"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e51874bd557fcc5809a3e133714998d2b856ab29aa59fba79f3398f0537e48"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "encoding_rs",
+ "libc",
+ "log",
+ "mozjs_sys",
+ "num-traits",
+]
+
+[[package]]
+name = "mozjs_sys"
+version = "0.140.8-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70e26e45204d1cbd73d2508007ab5cbb3411bddb057c47977bae6844861a8fa"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "encoding_c",
+ "encoding_c_mem",
+ "flate2",
+ "icu_capi",
+ "libc",
+ "libz-sys",
+ "tar",
+ "walkdir",
+]
+
+[[package]]
 name = "nalgebra"
 version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1828,7 +4345,7 @@ dependencies = [
  "approx",
  "matrixmultiply",
  "nalgebra-macros",
- "num-complex",
+ "num-complex 0.4.6",
  "num-rational",
  "num-traits",
  "simba",
@@ -1843,8 +4360,14 @@ checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -1863,12 +4386,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom-language"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
+dependencies = [
+ "nom 8.0.0",
+]
+
+[[package]]
+name = "nom-rfc8288"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf26c6675a34266d3d71137fc5d876adb5e3d74963181397fd39742a8341576"
+dependencies = [
+ "itertools 0.14.0",
+ "nom 8.0.0",
+ "nom-language",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -1882,9 +4441,12 @@ dependencies = [
 
 [[package]]
 name = "notify-types"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1906,6 +4468,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,11 +4504,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1941,6 +4558,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1965,9 +4602,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -1978,10 +4615,12 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -1990,9 +4629,52 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -2007,9 +4689,44 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2022,10 +4739,55 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "object"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "ocb3"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
+name = "ohos-media-sys"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6384d6e3befdaaec0206772e05a6b9222188e8ce023f6a164ca96e1091ef2e87"
+dependencies = [
+ "ohos-sys-opaque-types",
+]
+
+[[package]]
+name = "ohos-sys-opaque-types"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97f72e2121a94c07908afa7ae845775f02a51dbc4c691a96710151a00043203d"
+
+[[package]]
+name = "ohos-window-sys"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f801f5de727bd01cfdcd6e9b0de9d6d3e674e0ac73ea7ee202c0bcd75fc1daf7"
+dependencies = [
+ "ohos-sys-opaque-types",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2034,16 +4796,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl-probe"
-version = "0.2.0"
+name = "opaque-debug"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openxr"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40adeaa3219baa4412a522742eeee152656763008a39c68a50fd3027fe37625e"
+dependencies = [
+ "libc",
+ "libloading",
+ "ndk-context",
+ "openxr-sys",
+]
+
+[[package]]
+name = "openxr-sys"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b94052f57756896c60b504769568fc538808210e77190b69c69b467ee7eaaf"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordermap"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2",
+]
 
 [[package]]
 name = "pango"
@@ -2113,9 +4946,20 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2125,10 +4969,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "peek-poke"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef60922033e31835f6cf98b9b81b58368037b71d2a81928985cd9d0b3b3171fb"
+dependencies = [
+ "euclid",
+ "peek-poke-derive",
+]
+
+[[package]]
+name = "peek-poke-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271f78bae1e699b58c180a384a2e8d78ccbb60b853e15db92339725f3a2764d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "peniko"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3c76095c9a636173600478e0373218c7b955335048c2bcd12dc6a79657649d8"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo 0.12.0",
+ "linebender_resource_handle",
+ "smallvec",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2137,13 +5031,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
+dependencies = [
+ "fixedbitset",
+ "ordermap",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -2152,8 +5067,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2167,16 +5092,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.3",
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2198,16 +5146,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.16"
+name = "pico-args"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
+name = "pin-project"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "rand_core 0.6.4",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2216,16 +5206,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "png"
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plane-split"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+checksum = "8c1f7d82649829ecdef8e258790b0587acf0a8403f0ce963473d8e918acc1643"
 dependencies = [
- "bitflags 2.10.0",
+ "euclid",
+ "log",
+ "smallvec",
+]
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -2234,8 +5304,16 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
- "zerovec",
+ "serde_core",
+ "writeable 0.6.2",
+ "zerovec 0.11.5",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2253,19 +5331,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.104"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -2287,7 +5384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2322,12 +5419,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
-dependencies = [
- "num-traits",
-]
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "quick-error"
@@ -2337,74 +5431,29 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
+name = "quick_cache"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "530e84778a55de0f52645a51d4e3b9554978acd6a1e7cd50b6a6784692b3029e"
 dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash 2.1.1",
- "rustls",
- "socket2",
- "thiserror 2.0.17",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.2",
- "ring",
- "rustc-hash 2.1.1",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.17",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
+ "ahash",
+ "equivalent",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2416,11 +5465,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -2430,8 +5500,28 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core 0.9.3",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2441,7 +5531,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -2449,14 +5548,82 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
 ]
 
 [[package]]
@@ -2498,12 +5665,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e03e7866abec1101869ffa8e2c8355c4c2419d0214ece0cc3e428e5b94dea6e9"
 
 [[package]]
+name = "read-fonts"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2512,28 +5698,37 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.14",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "e9368763f5a9b804326f3af749e16f9abf378d227bcdee7634b13d8f17793782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2542,52 +5737,42 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "reqwest"
-version = "0.13.1"
+name = "resvg"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
 dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
+ "gif 0.13.3",
+ "image-webp",
  "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg 0.4.21",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
 name = "rgb"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
 ]
@@ -2600,28 +5785,74 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.38.0"
+name = "ron"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
+checksum = "beceb6f7bf81c73e73aeef6dd1356d9a1b2b4909e1f0fc3e59b034f9572d7b7f"
 dependencies = [
- "bitflags 2.10.0",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha1",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags 2.11.0",
  "chrono",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
- "sqlite-wasm-rs",
  "uuid",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -2631,9 +5862,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2650,7 +5881,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2659,24 +5890,25 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -2698,11 +5930,10 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -2712,7 +5943,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -2735,9 +5966,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2750,6 +5981,30 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
@@ -2771,9 +6026,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2791,13 +6046,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "security-framework"
-version = "3.5.1"
+name = "sea-query"
+version = "1.0.0-rc.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "58decdaaaf2a698170af2fa1b2e8f7b43a970e7768bf18aebaab113bada46354"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "inherent",
+ "sea-query-derive",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "1.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d88ad44b6ad9788c8b9476b6b91f94c7461d1e19d39cd8ea37838b1e6ff5aa8"
+dependencies = [
+ "darling",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sea-query-rusqlite"
+version = "0.8.0-rc.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d42855d86ace6f5d9e425b65a8035d45c64e001db87a254ecfd87f226b4b0f7"
+dependencies = [
+ "rusqlite",
+ "sea-query",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2805,9 +6108,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2819,17 +6122,37 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5685b6ae43bfcf7d2e7dfcfb5d8e8f61b46442c902531e41a32a9a8bf0ee0fb6"
 dependencies = [
- "bitflags 2.10.0",
- "cssparser",
+ "bitflags 2.11.0",
+ "cssparser 0.35.0",
  "derive_more",
  "fxhash",
  "log",
  "new_debug_unreachable",
- "phf",
- "phf_codegen",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
  "precomputed-hash",
- "servo_arc",
+ "servo_arc 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec",
+]
+
+[[package]]
+name = "selectors"
+version = "0.37.0"
+source = "git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547#96ceb5405bd7ce10c4141c62e860d50745a75547"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser 0.36.0",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash 2.1.2",
+ "servo_arc 0.4.3 (git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547)",
+ "smallvec",
+ "to_shmem",
+ "to_shmem_derive",
 ]
 
 [[package]]
@@ -2849,6 +6172,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2865,15 +6198,16 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2891,12 +6225,1445 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "servo"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "accesskit",
+ "arboard",
+ "bitflags 2.11.0",
+ "cookie 0.18.1",
+ "crossbeam-channel",
+ "dpi",
+ "env_logger",
+ "euclid",
+ "gaol",
+ "http 1.4.0",
+ "image",
+ "ipc-channel",
+ "keyboard-types",
+ "log",
+ "mozangle",
+ "parking_lot",
+ "rustc-hash 2.1.2",
+ "serde",
+ "servo-background-hang-monitor",
+ "servo-base",
+ "servo-canvas-traits",
+ "servo-config",
+ "servo-constellation",
+ "servo-constellation-traits",
+ "servo-default-resources",
+ "servo-devtools",
+ "servo-devtools-traits",
+ "servo-embedder-traits",
+ "servo-fonts",
+ "servo-geometry",
+ "servo-layout",
+ "servo-layout-api",
+ "servo-media",
+ "servo-media-dummy",
+ "servo-media-ohos",
+ "servo-media-thread",
+ "servo-net",
+ "servo-net-traits",
+ "servo-paint",
+ "servo-paint-api",
+ "servo-profile",
+ "servo-profile-traits",
+ "servo-script",
+ "servo-script-traits",
+ "servo-storage",
+ "servo-storage-traits",
+ "servo-tracing",
+ "servo-url",
+ "servo-wakelock",
+ "servo-webgl",
+ "servo-webxr",
+ "stylo",
+ "stylo_traits",
+ "surfman",
+ "tokio",
+ "url",
+ "webrender",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-allocator"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+ "tikv-jemallocator",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "servo-background-hang-monitor"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "backtrace",
+ "crossbeam-channel",
+ "libc",
+ "log",
+ "rustc-hash 2.1.2",
+ "serde_json",
+ "servo-background-hang-monitor-api",
+ "servo-base",
+]
+
+[[package]]
+name = "servo-background-hang-monitor-api"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "serde",
+ "servo-base",
+]
+
+[[package]]
+name = "servo-base"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "accesskit",
+ "crossbeam-channel",
+ "ipc-channel",
+ "libc",
+ "log",
+ "mach2",
+ "malloc_size_of_derive",
+ "parking_lot",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "servo-config",
+ "servo-malloc-size-of",
+ "time",
+ "unicode-segmentation",
+ "webrender_api",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "servo-canvas"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "bytemuck",
+ "crossbeam-channel",
+ "euclid",
+ "kurbo 0.12.0",
+ "log",
+ "peniko",
+ "rustc-hash 2.1.2",
+ "servo-base",
+ "servo-canvas-traits",
+ "servo-config",
+ "servo-fonts",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-tracing",
+ "stylo",
+ "vello_cpu",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-canvas-traits"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "crossbeam-channel",
+ "euclid",
+ "glow",
+ "kurbo 0.12.0",
+ "malloc_size_of_derive",
+ "serde",
+ "servo-base",
+ "servo-fonts-traits",
+ "servo-malloc-size-of",
+ "servo-pixels",
+ "servo-webxr-api",
+ "strum",
+ "stylo",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-config"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "serde",
+ "serde_json",
+ "servo-config-macro",
+ "stylo_static_prefs",
+]
+
+[[package]]
+name = "servo-config-macro"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "servo-constellation"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "accesskit",
+ "backtrace",
+ "base64 0.22.1",
+ "content-security-policy",
+ "crossbeam-channel",
+ "euclid",
+ "gaol",
+ "ipc-channel",
+ "keyboard-types",
+ "log",
+ "parking_lot",
+ "rand 0.9.2",
+ "rustc-hash 2.1.2",
+ "serde",
+ "servo-background-hang-monitor",
+ "servo-background-hang-monitor-api",
+ "servo-base",
+ "servo-canvas",
+ "servo-canvas-traits",
+ "servo-config",
+ "servo-constellation-traits",
+ "servo-devtools-traits",
+ "servo-embedder-traits",
+ "servo-fonts",
+ "servo-layout-api",
+ "servo-media-thread",
+ "servo-net",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-profile-traits",
+ "servo-script-traits",
+ "servo-storage-traits",
+ "servo-tracing",
+ "servo-url",
+ "servo-wakelock",
+ "servo-webxr-api",
+ "stylo",
+ "stylo_traits",
+]
+
+[[package]]
+name = "servo-constellation-traits"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "base64 0.22.1",
+ "content-security-policy",
+ "encoding_rs",
+ "euclid",
+ "http 1.4.0",
+ "ipc-channel",
+ "log",
+ "malloc_size_of_derive",
+ "rustc-hash 2.1.2",
+ "serde",
+ "servo-base",
+ "servo-canvas-traits",
+ "servo-config",
+ "servo-devtools-traits",
+ "servo-embedder-traits",
+ "servo-fonts-traits",
+ "servo-hyper-serde",
+ "servo-malloc-size-of",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-storage-traits",
+ "servo-url",
+ "servo-wakelock",
+ "strum",
+ "uuid",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-default-resources"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "servo-embedder-traits",
+]
+
+[[package]]
+name = "servo-deny-public-fields"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "servo-devtools"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "atomic_refcell",
+ "base64 0.22.1",
+ "chrono",
+ "crossbeam-channel",
+ "headers 0.4.1",
+ "http 1.4.0",
+ "log",
+ "malloc_size_of_derive",
+ "rand 0.9.2",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_json",
+ "servo-base",
+ "servo-config",
+ "servo-devtools-traits",
+ "servo-embedder-traits",
+ "servo-malloc-size-of",
+ "servo-net",
+ "servo-net-traits",
+ "servo-profile-traits",
+ "servo-url",
+ "uuid",
+]
+
+[[package]]
+name = "servo-devtools-traits"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "http 1.4.0",
+ "malloc_size_of_derive",
+ "serde",
+ "servo-base",
+ "servo-embedder-traits",
+ "servo-malloc-size-of",
+ "servo-net-traits",
+ "servo-profile-traits",
+ "servo-url",
+ "uuid",
+]
+
+[[package]]
+name = "servo-dom-struct"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "servo-embedder-traits"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "accesskit",
+ "bitflags 2.11.0",
+ "cookie 0.18.1",
+ "crossbeam-channel",
+ "euclid",
+ "http 1.4.0",
+ "image",
+ "inventory",
+ "keyboard-types",
+ "log",
+ "malloc_size_of_derive",
+ "rustc-hash 2.1.2",
+ "serde",
+ "servo-base",
+ "servo-geometry",
+ "servo-hyper-serde",
+ "servo-malloc-size-of",
+ "servo-pixels",
+ "servo-url",
+ "strum",
+ "stylo",
+ "stylo_traits",
+ "url",
+ "uuid",
+ "webdriver",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-fonts"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "app_units",
+ "bitflags 2.11.0",
+ "byteorder",
+ "content-security-policy",
+ "dwrote",
+ "euclid",
+ "fontsan",
+ "freetype-sys",
+ "harfbuzz-sys",
+ "icu_locid",
+ "icu_properties 1.5.1",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "malloc_size_of_derive",
+ "memmap2",
+ "num-traits",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-text",
+ "parking_lot",
+ "read-fonts",
+ "rustc-hash 2.1.2",
+ "serde",
+ "servo-allocator",
+ "servo-base",
+ "servo-config",
+ "servo-fonts-traits",
+ "servo-malloc-size-of",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-profile-traits",
+ "servo-tracing",
+ "servo-url",
+ "servo_arc 0.4.3 (git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547)",
+ "skrifa",
+ "smallvec",
+ "stylo",
+ "stylo_atoms",
+ "unicode-properties",
+ "unicode-script",
+ "url",
+ "uuid",
+ "webrender_api",
+ "winapi",
+ "xml",
+ "yeslogic-fontconfig-sys",
+]
+
+[[package]]
+name = "servo-fonts-traits"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "atomic_refcell",
+ "dwrote",
+ "log",
+ "malloc_size_of_derive",
+ "memmap2",
+ "num-derive",
+ "num-traits",
+ "parking_lot",
+ "read-fonts",
+ "serde",
+ "servo-base",
+ "servo-malloc-size-of",
+ "servo-profile-traits",
+ "servo-url",
+ "stylo",
+ "uuid",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-geometry"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "app_units",
+ "euclid",
+ "malloc_size_of_derive",
+ "servo-malloc-size-of",
+ "webrender",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-hyper-serde"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "cookie 0.18.1",
+ "headers 0.4.1",
+ "http 1.4.0",
+ "hyper 1.9.0",
+ "mime",
+ "serde_bytes",
+ "serde_core",
+]
+
+[[package]]
+name = "servo-jstraceable-derive"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "servo-layout"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "accesskit",
+ "app_units",
+ "atomic_refcell",
+ "bitflags 2.11.0",
+ "data-url",
+ "euclid",
+ "icu_locid",
+ "icu_segmenter 1.5.0",
+ "itertools 0.14.0",
+ "kurbo 0.12.0",
+ "log",
+ "malloc_size_of_derive",
+ "parking_lot",
+ "rayon",
+ "rustc-hash 2.1.2",
+ "selectors 0.37.0",
+ "serde",
+ "servo-base",
+ "servo-config",
+ "servo-embedder-traits",
+ "servo-fonts",
+ "servo-fonts-traits",
+ "servo-geometry",
+ "servo-layout-api",
+ "servo-malloc-size-of",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-script",
+ "servo-script-traits",
+ "servo-tracing",
+ "servo-url",
+ "servo_arc 0.4.3 (git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547)",
+ "smallvec",
+ "strum",
+ "stylo",
+ "stylo_atoms",
+ "stylo_traits",
+ "taffy",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode_categories",
+ "url",
+ "web_atoms 0.2.3",
+ "webrender_api",
+ "xi-unicode",
+]
+
+[[package]]
+name = "servo-layout-api"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "app_units",
+ "atomic_refcell",
+ "bitflags 2.11.0",
+ "euclid",
+ "html5ever",
+ "libc",
+ "malloc_size_of_derive",
+ "parking_lot",
+ "rustc-hash 2.1.2",
+ "selectors 0.37.0",
+ "serde",
+ "servo-background-hang-monitor-api",
+ "servo-base",
+ "servo-embedder-traits",
+ "servo-fonts",
+ "servo-malloc-size-of",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-script-traits",
+ "servo-url",
+ "servo_arc 0.4.3 (git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547)",
+ "stylo",
+ "stylo_traits",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-malloc-size-of"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "accountable-refcell",
+ "app_units",
+ "atomic_refcell",
+ "content-security-policy",
+ "crossbeam-channel",
+ "data-url",
+ "encoding_rs",
+ "euclid",
+ "http 1.4.0",
+ "icu_locid",
+ "indexmap",
+ "ipc-channel",
+ "keyboard-types",
+ "markup5ever 0.39.0",
+ "mime",
+ "parking_lot",
+ "resvg",
+ "servo-allocator",
+ "servo_arc 0.4.3 (git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547)",
+ "smallvec",
+ "string_cache 0.9.0",
+ "stylo",
+ "stylo_dom",
+ "stylo_malloc_size_of",
+ "taffy",
+ "tendril 0.5.0",
+ "time",
+ "tokio",
+ "unicode-bidi",
+ "unicode-script",
+ "url",
+ "urlpattern",
+ "uuid",
+ "webrender",
+ "webrender_api",
+ "wr_malloc_size_of",
+]
+
+[[package]]
+name = "servo-media"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "once_cell",
+ "servo-media-audio",
+ "servo-media-player",
+ "servo-media-streams",
+ "servo-media-traits",
+ "servo-media-webrtc",
+]
+
+[[package]]
+name = "servo-media-audio"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "byte-slice-cast",
+ "euclid",
+ "log",
+ "malloc_size_of_derive",
+ "num-complex 0.2.4",
+ "num-traits",
+ "petgraph",
+ "serde",
+ "serde_derive",
+ "servo-malloc-size-of",
+ "servo-media-derive",
+ "servo-media-player",
+ "servo-media-streams",
+ "servo-media-traits",
+ "smallvec",
+ "speexdsp-resampler",
+]
+
+[[package]]
+name = "servo-media-derive"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "servo-media-dummy"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "ipc-channel",
+ "servo-media",
+ "servo-media-audio",
+ "servo-media-player",
+ "servo-media-streams",
+ "servo-media-traits",
+ "servo-media-webrtc",
+]
+
+[[package]]
+name = "servo-media-ohos"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "crossbeam-channel",
+ "ipc-channel",
+ "libc",
+ "log",
+ "lru",
+ "mime",
+ "ohos-media-sys",
+ "ohos-sys-opaque-types",
+ "ohos-window-sys",
+ "once_cell",
+ "rangemap",
+ "serde_json",
+ "servo-media",
+ "servo-media-audio",
+ "servo-media-player",
+ "servo-media-streams",
+ "servo-media-traits",
+ "servo-media-webrtc",
+ "yuv",
+]
+
+[[package]]
+name = "servo-media-player"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "ipc-channel",
+ "malloc_size_of_derive",
+ "serde",
+ "serde_derive",
+ "servo-malloc-size-of",
+ "servo-media-streams",
+ "servo-media-traits",
+]
+
+[[package]]
+name = "servo-media-streams"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "malloc_size_of_derive",
+ "servo-malloc-size-of",
+ "uuid",
+]
+
+[[package]]
+name = "servo-media-thread"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "euclid",
+ "ipc-channel",
+ "log",
+ "malloc_size_of_derive",
+ "rustc-hash 2.1.2",
+ "serde",
+ "servo-config",
+ "servo-malloc-size-of",
+ "servo-media",
+ "servo-paint-api",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-media-traits"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "malloc_size_of_derive",
+ "servo-malloc-size-of",
+]
+
+[[package]]
+name = "servo-media-webrtc"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "log",
+ "servo-media-streams",
+ "uuid",
+]
+
+[[package]]
+name = "servo-metrics"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "malloc_size_of_derive",
+ "servo-base",
+ "servo-config",
+ "servo-malloc-size-of",
+ "servo-paint-api",
+ "servo-profile-traits",
+ "servo-script-traits",
+ "servo-url",
+]
+
+[[package]]
+name = "servo-net"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "async-compression",
+ "async-recursion",
+ "async-tungstenite",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "content-security-policy",
+ "cookie 0.18.1",
+ "crossbeam-channel",
+ "data-url",
+ "fst",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "generic-array",
+ "headers 0.4.1",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-rustls",
+ "hyper-util",
+ "imsz",
+ "ipc-channel",
+ "itertools 0.14.0",
+ "log",
+ "malloc_size_of_derive",
+ "mime",
+ "mime_guess",
+ "nom 8.0.0",
+ "parking_lot",
+ "quick_cache",
+ "regex",
+ "resvg",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "servo-base",
+ "servo-config",
+ "servo-devtools-traits",
+ "servo-embedder-traits",
+ "servo-hyper-serde",
+ "servo-malloc-size-of",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-url",
+ "servo_arc 0.4.3 (git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547)",
+ "sha2",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tungstenite",
+ "url",
+ "uuid",
+ "webpki-roots",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-net-traits"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "content-security-policy",
+ "cookie 0.18.1",
+ "crossbeam-channel",
+ "data-url",
+ "headers 0.4.1",
+ "http 1.4.0",
+ "hyper-util",
+ "ipc-channel",
+ "log",
+ "malloc_size_of_derive",
+ "mime",
+ "num-traits",
+ "parking_lot",
+ "percent-encoding",
+ "rand 0.9.2",
+ "rustc-hash 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "servo-base",
+ "servo-config",
+ "servo-embedder-traits",
+ "servo-hyper-serde",
+ "servo-malloc-size-of",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-url",
+ "servo_arc 0.4.3 (git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547)",
+ "sys-locale",
+ "tokio",
+ "url",
+ "uuid",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-paint"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "dpi",
+ "euclid",
+ "gleam",
+ "image",
+ "ipc-channel",
+ "log",
+ "rayon",
+ "rustc-hash 2.1.2",
+ "servo-allocator",
+ "servo-base",
+ "servo-canvas-traits",
+ "servo-config",
+ "servo-constellation-traits",
+ "servo-embedder-traits",
+ "servo-geometry",
+ "servo-malloc-size-of",
+ "servo-media-thread",
+ "servo-paint-api",
+ "servo-profile-traits",
+ "servo-timers",
+ "servo-tracing",
+ "servo-webgl",
+ "smallvec",
+ "stylo_traits",
+ "surfman",
+ "webrender",
+ "webrender_api",
+ "wr_malloc_size_of",
+]
+
+[[package]]
+name = "servo-paint-api"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "dpi",
+ "euclid",
+ "gleam",
+ "glow",
+ "image",
+ "ipc-channel",
+ "log",
+ "malloc_size_of_derive",
+ "parking_lot",
+ "raw-window-handle",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_bytes",
+ "servo-base",
+ "servo-embedder-traits",
+ "servo-geometry",
+ "servo-malloc-size-of",
+ "servo-profile-traits",
+ "servo-tracing",
+ "servo-url",
+ "smallvec",
+ "strum",
+ "stylo",
+ "stylo_traits",
+ "surfman",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-pixels"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "euclid",
+ "image",
+ "log",
+ "malloc_size_of_derive",
+ "serde",
+ "servo-base",
+ "servo-malloc-size-of",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-profile"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "libc",
+ "log",
+ "mach2",
+ "regex",
+ "serde",
+ "serde_json",
+ "servo-allocator",
+ "servo-base",
+ "servo-config",
+ "servo-profile-traits",
+ "tikv-jemalloc-sys",
+ "time",
+]
+
+[[package]]
+name = "servo-profile-traits"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "crossbeam-channel",
+ "ipc-channel",
+ "log",
+ "malloc_size_of_derive",
+ "serde",
+ "servo-allocator",
+ "servo-base",
+ "servo-malloc-size-of",
+ "time",
+]
+
+[[package]]
+name = "servo-script"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "aes-kw",
+ "app_units",
+ "argon2",
+ "arrayvec",
+ "atomic_refcell",
+ "aws-lc-rs",
+ "backtrace",
+ "base64 0.22.1",
+ "base64ct",
+ "bitflags 2.11.0",
+ "brotli",
+ "cbc",
+ "chacha20poly1305",
+ "chardetng",
+ "chrono",
+ "cipher",
+ "content-security-policy",
+ "cookie 0.18.1",
+ "crossbeam-channel",
+ "cssparser 0.36.0",
+ "ctr",
+ "data-url",
+ "der",
+ "digest",
+ "ecdsa",
+ "elliptic-curve",
+ "encoding_rs",
+ "euclid",
+ "flate2",
+ "glow",
+ "headers 0.4.1",
+ "hkdf",
+ "html5ever",
+ "http 1.4.0",
+ "icu_locid",
+ "indexmap",
+ "ipc-channel",
+ "itertools 0.14.0",
+ "keyboard-types",
+ "libc",
+ "log",
+ "malloc_size_of_derive",
+ "markup5ever 0.39.0",
+ "mime",
+ "mime-multipart-hyper1",
+ "mime_guess",
+ "ml-dsa",
+ "ml-kem",
+ "mozangle",
+ "mozjs",
+ "nom-rfc8288",
+ "num-bigint-dig",
+ "num-traits",
+ "num_cpus",
+ "ocb3",
+ "p256",
+ "p384",
+ "p521",
+ "parking_lot",
+ "percent-encoding",
+ "phf 0.13.1",
+ "pkcs8",
+ "postcard",
+ "rand 0.9.2",
+ "regex",
+ "rsa",
+ "rustc-hash 2.1.2",
+ "sec1",
+ "selectors 0.37.0",
+ "serde",
+ "serde_json",
+ "servo-background-hang-monitor-api",
+ "servo-base",
+ "servo-canvas-traits",
+ "servo-config",
+ "servo-constellation-traits",
+ "servo-deny-public-fields",
+ "servo-devtools-traits",
+ "servo-dom-struct",
+ "servo-embedder-traits",
+ "servo-fonts",
+ "servo-fonts-traits",
+ "servo-geometry",
+ "servo-hyper-serde",
+ "servo-jstraceable-derive",
+ "servo-layout-api",
+ "servo-malloc-size-of",
+ "servo-media",
+ "servo-media-thread",
+ "servo-metrics",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-script-bindings",
+ "servo-script-traits",
+ "servo-storage-traits",
+ "servo-timers",
+ "servo-url",
+ "servo-wakelock",
+ "servo-xpath",
+ "servo_arc 0.4.3 (git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547)",
+ "sha1",
+ "sha2",
+ "sha3",
+ "smallvec",
+ "strum",
+ "stylo",
+ "stylo_atoms",
+ "stylo_dom",
+ "stylo_malloc_size_of",
+ "stylo_traits",
+ "swapper",
+ "tempfile",
+ "tendril 0.5.0",
+ "time",
+ "unicode-bidi",
+ "unicode-script",
+ "url",
+ "urlpattern",
+ "uuid",
+ "webdriver",
+ "webrender_api",
+ "x25519-dalek",
+ "xml5ever 0.39.0",
+]
+
+[[package]]
+name = "servo-script-bindings"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "encoding_rs",
+ "html5ever",
+ "indexmap",
+ "keyboard-types",
+ "libc",
+ "log",
+ "malloc_size_of_derive",
+ "mozjs",
+ "num-traits",
+ "parking_lot",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "phf_shared 0.13.1",
+ "regex",
+ "serde_json",
+ "servo-base",
+ "servo-config",
+ "servo-deny-public-fields",
+ "servo-dom-struct",
+ "servo-jstraceable-derive",
+ "servo-malloc-size-of",
+ "servo-profile-traits",
+ "servo-url",
+ "servo_arc 0.4.3 (git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547)",
+ "smallvec",
+ "stylo",
+ "stylo_atoms",
+ "tendril 0.5.0",
+ "xml5ever 0.39.0",
+]
+
+[[package]]
+name = "servo-script-traits"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "accesskit",
+ "crossbeam-channel",
+ "euclid",
+ "keyboard-types",
+ "malloc_size_of_derive",
+ "rustc-hash 2.1.2",
+ "serde",
+ "servo-base",
+ "servo-canvas-traits",
+ "servo-config",
+ "servo-constellation-traits",
+ "servo-devtools-traits",
+ "servo-embedder-traits",
+ "servo-fonts-traits",
+ "servo-malloc-size-of",
+ "servo-media-thread",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-storage-traits",
+ "servo-url",
+ "servo-webxr-api",
+ "strum",
+ "stylo_atoms",
+ "stylo_traits",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-storage"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "libc",
+ "log",
+ "malloc_size_of_derive",
+ "postcard",
+ "rusqlite",
+ "rustc-hash 2.1.2",
+ "sea-query",
+ "sea-query-rusqlite",
+ "serde",
+ "servo-base",
+ "servo-config",
+ "servo-malloc-size-of",
+ "servo-net-traits",
+ "servo-profile-traits",
+ "servo-storage-traits",
+ "servo-url",
+ "tempfile",
+ "uuid",
+]
+
+[[package]]
+name = "servo-storage-traits"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "malloc_size_of_derive",
+ "serde",
+ "servo-base",
+ "servo-malloc-size-of",
+ "servo-profile-traits",
+ "servo-url",
+ "uuid",
+]
+
+[[package]]
+name = "servo-timers"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "crossbeam-channel",
+ "malloc_size_of_derive",
+ "servo-malloc-size-of",
+]
+
+[[package]]
+name = "servo-tracing"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "servo-url"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "encoding_rs",
+ "malloc_size_of_derive",
+ "serde",
+ "servo-malloc-size-of",
+ "servo_arc 0.4.3 (git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547)",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "servo-wakelock"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "servo-webgl"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "bitflags 2.11.0",
+ "byteorder",
+ "crossbeam-channel",
+ "euclid",
+ "glow",
+ "half",
+ "itertools 0.14.0",
+ "log",
+ "parking_lot",
+ "rustc-hash 2.1.2",
+ "servo-base",
+ "servo-canvas-traits",
+ "servo-paint-api",
+ "servo-pixels",
+ "surfman",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-webxr"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "crossbeam-channel",
+ "euclid",
+ "glow",
+ "log",
+ "openxr",
+ "raw-window-handle",
+ "servo-base",
+ "servo-profile-traits",
+ "servo-webxr-api",
+ "surfman",
+ "winapi",
+ "wio",
+]
+
+[[package]]
+name = "servo-webxr-api"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "euclid",
+ "ipc-channel",
+ "log",
+ "malloc_size_of_derive",
+ "serde",
+ "servo-base",
+ "servo-embedder-traits",
+ "servo-malloc-size-of",
+ "servo-profile-traits",
+]
+
+[[package]]
+name = "servo-xpath"
+version = "0.1.0"
+source = "git+https://github.com/chrisduerr/servo?rev=36c07f4e4f0fbbd775d68171a3767053e8a24b5e#36c07f4e4f0fbbd775d68171a3767053e8a24b5e"
+dependencies = [
+ "log",
+ "malloc_size_of_derive",
+ "markup5ever 0.39.0",
+ "servo-malloc-size-of",
+]
+
+[[package]]
 name = "servo_arc"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547#96ceb5405bd7ce10c4141c62e860d50745a75547"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]
@@ -2921,13 +7688,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simba"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
 dependencies = [
  "approx",
- "num-complex",
+ "num-complex 0.4.6",
  "num-traits",
  "paste",
  "wide",
@@ -2940,22 +7717,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
-name = "siphasher"
-version = "1.0.1"
+name = "simd_helpers"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "skrifa"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "smallbitvec"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d31d263dd118560e1a492922182ab6ca6dc1d03a3bf54e7699993f31a4150e3f"
 
 [[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -2963,15 +7786,15 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "cursor-icon",
  "libc",
  "log",
  "memmap2",
  "pkg-config",
- "rustix 1.1.3",
- "thiserror 2.0.17",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -2987,12 +7810,22 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3022,16 +7855,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlite-wasm-rs"
-version = "0.5.1"
+name = "speexdsp-resampler"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e98301bf8b0540c7de45ecd760539b9c62f5772aed172f08efba597c11cd5d"
+checksum = "b72d540d5c565dbe1f891d7e21ceb21d2649508306782f1066989fccb0b363d3"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
- "cc",
- "hashbrown 0.16.1",
- "js-sys",
- "thiserror 2.0.17",
- "wasm-bindgen",
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -3039,6 +7881,37 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strck"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be91090ded9d8f979d9fe921777342d37e769e0b6b7296843a7a38247240e917"
+
+[[package]]
+name = "strck_ident"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c3802b169b3858a44667f221c9a0b3136e6019936ea926fc97fbad8af77202"
+dependencies = [
+ "strck",
+ "unicode-ident",
+]
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp 0.9.0",
+]
 
 [[package]]
 name = "string_cache"
@@ -3072,8 +7945,20 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -3085,10 +7970,212 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "stylo"
+version = "0.16.0"
+source = "git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547#96ceb5405bd7ce10c4141c62e860d50745a75547"
+dependencies = [
+ "app_units",
+ "arrayvec",
+ "atomic_refcell",
+ "bitflags 2.11.0",
+ "byteorder",
+ "cssparser 0.36.0",
+ "derive_more",
+ "encoding_rs",
+ "euclid",
+ "icu_segmenter 2.1.2",
+ "indexmap",
+ "itertools 0.14.0",
+ "itoa",
+ "log",
+ "malloc_size_of_derive",
+ "mime",
+ "new_debug_unreachable",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "num_cpus",
+ "parking_lot",
+ "precomputed-hash",
+ "rayon",
+ "rayon-core",
+ "rustc-hash 2.1.2",
+ "selectors 0.37.0",
+ "serde",
+ "servo_arc 0.4.3 (git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547)",
+ "smallbitvec",
+ "smallvec",
+ "static_assertions",
+ "string_cache 0.9.0",
+ "strum",
+ "strum_macros",
+ "stylo_atoms",
+ "stylo_derive",
+ "stylo_dom",
+ "stylo_malloc_size_of",
+ "stylo_static_prefs",
+ "stylo_traits",
+ "thin-vec",
+ "to_shmem",
+ "to_shmem_derive",
+ "uluru",
+ "url",
+ "void",
+ "walkdir",
+ "web_atoms 0.2.3",
+]
+
+[[package]]
+name = "stylo_atoms"
+version = "0.16.0"
+source = "git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547#96ceb5405bd7ce10c4141c62e860d50745a75547"
+dependencies = [
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
+]
+
+[[package]]
+name = "stylo_derive"
+version = "0.16.0"
+source = "git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547#96ceb5405bd7ce10c4141c62e860d50745a75547"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "stylo_dom"
+version = "0.16.0"
+source = "git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547#96ceb5405bd7ce10c4141c62e860d50745a75547"
+dependencies = [
+ "bitflags 2.11.0",
+ "stylo_malloc_size_of",
+]
+
+[[package]]
+name = "stylo_malloc_size_of"
+version = "0.16.0"
+source = "git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547#96ceb5405bd7ce10c4141c62e860d50745a75547"
+dependencies = [
+ "app_units",
+ "cssparser 0.36.0",
+ "euclid",
+ "selectors 0.37.0",
+ "servo_arc 0.4.3 (git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547)",
+ "smallbitvec",
+ "smallvec",
+ "string_cache 0.9.0",
+ "thin-vec",
+ "void",
+]
+
+[[package]]
+name = "stylo_static_prefs"
+version = "0.16.0"
+source = "git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547#96ceb5405bd7ce10c4141c62e860d50745a75547"
+
+[[package]]
+name = "stylo_traits"
+version = "0.16.0"
+source = "git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547#96ceb5405bd7ce10c4141c62e860d50745a75547"
+dependencies = [
+ "app_units",
+ "bitflags 2.11.0",
+ "cssparser 0.36.0",
+ "euclid",
+ "malloc_size_of_derive",
+ "selectors 0.37.0",
+ "serde",
+ "servo_arc 0.4.3 (git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547)",
+ "stylo_atoms",
+ "stylo_malloc_size_of",
+ "thin-vec",
+ "to_shmem",
+ "to_shmem_derive",
+ "url",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "surfman"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd46f11e3e56616d97db5ab0ba5ed53b215851afeef341657f0f6087d6c946e"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg_aliases",
+ "cgl",
+ "euclid",
+ "fnv",
+ "gl_generator",
+ "glow",
+ "libc",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-io-surface",
+ "objc2-metal",
+ "objc2-quartz-core",
+ "raw-window-handle",
+ "wayland-sys",
+ "winapi",
+ "wio",
+ "x11-dl",
+]
+
+[[package]]
+name = "svg_fmt"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo 0.11.3",
+ "siphasher",
+]
+
+[[package]]
+name = "swapper"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e454d048db5527d000bfddb77bd072bbf3a1e2ae785f16d9bd116e07c2ab45eb"
 
 [[package]]
 name = "syn"
@@ -3103,9 +8190,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.112"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f182278bf2d2bcb3c88b1b08a37df029d71ce3d3ae26168e3c653b213b99d4"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3117,9 +8204,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "synstructure"
@@ -3129,7 +8213,16 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3139,10 +8232,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
 dependencies = [
  "cfg-expr",
- "heck",
+ "heck 0.5.0",
  "pkg-config",
  "toml",
  "version-compare",
+]
+
+[[package]]
+name = "taffy"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aea22054047c16c3f34d3ac473a2170be1424b1115b2a3adcf28cfb067c88859"
+dependencies = [
+ "arrayvec",
+ "grid",
+ "serde",
+ "slotmap",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3153,14 +8269,14 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3176,6 +8292,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "encoding_rs",
+ "new_debug_unreachable",
+ "utf-8",
+]
+
+[[package]]
+name = "textnonce"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f8d70cd784ed1dc33106a18998d77758d281dc40dc3e6d050cf0f5286683"
+dependencies = [
+ "base64 0.12.3",
+ "rand 0.7.3",
+]
+
+[[package]]
+name = "thin-vec"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3186,11 +8329,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3201,18 +8344,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3225,13 +8368,117 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg 0.4.21",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.17.16",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec 0.10.4",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
- "zerovec",
+ "serde_core",
+ "zerovec 0.11.5",
 ]
 
 [[package]]
@@ -3250,17 +8497,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "to_shmem"
+version = "0.3.0"
+source = "git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547#96ceb5405bd7ce10c4141c62e860d50745a75547"
+dependencies = [
+ "cssparser 0.36.0",
+ "servo_arc 0.4.3 (git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547)",
+ "smallbitvec",
+ "smallvec",
+ "string_cache 0.9.0",
+ "thin-vec",
+]
+
+[[package]]
+name = "to_shmem_derive"
+version = "0.1.0"
+source = "git+https://github.com/servo/stylo?rev=96ceb5405bd7ce10c4141c62e860d50745a75547#96ceb5405bd7ce10c4141c62e860d50745a75547"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3274,15 +8558,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.9.10+spec-1.1.0"
+name = "tokio-stream"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -3298,22 +8606,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -3325,34 +8642,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
-name = "tower"
-version = "0.5.2"
+name = "topological-sort"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "aa7c7f42dea4b1b99439786f5633aeb9c14c1b53f75e282803c2ec2ad545873c"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
-dependencies = [
- "bitflags 2.10.0",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "iri-string",
- "pin-project-lite",
- "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -3375,6 +8679,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3388,7 +8693,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3414,14 +8719,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata",
+ "regex-automata 0.4.14",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -3431,10 +8736,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracy-rs"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce607aae8ab0ab3abf3a2723a9ab6f09bb8639ed83fdd888d857b8e556c868d8"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "typenum"
@@ -3443,10 +8781,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.22"
+name = "uluru"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "unic-char-property"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
+dependencies = [
+ "unic-char-range",
+]
+
+[[package]]
+name = "unic-char-range"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
+
+[[package]]
+name = "unic-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-ucd-ident"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e230a37c0381caa9219d67cf063aa3a375ffed5bf541a452db16e744bdab6987"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
+dependencies = [
+ "unic-common",
+]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -3456,14 +8914,54 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "urlpattern"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70acd30e3aa1450bc2eece896ce2ad0d178e9c079493819301573dae3c37ba6d"
+dependencies = [
+ "regex",
+ "serde",
+ "unic-ucd-ident",
+ "url",
+]
+
+[[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo 0.11.3",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -3471,6 +8969,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -3486,12 +8990,25 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
+ "sha1_smol",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
  "wasm-bindgen",
 ]
 
@@ -3508,10 +9025,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vello_common"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a235ba928b3109ad9e7696270edb09445a52ae1c7c08e6d31a19b1cdd6cbc24a"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "hashbrown 0.15.5",
+ "log",
+ "peniko",
+ "png 0.17.16",
+ "skrifa",
+ "smallvec",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0bd1fcf9c1814f17a491e07113623d44e3ec1125a9f3401f5e047d6d326da21"
+dependencies = [
+ "bytemuck",
+ "vello_common",
+]
+
+[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"
@@ -3533,6 +9088,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "warp"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "headers 0.3.9",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3544,14 +9132,23 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3561,23 +9158,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3585,35 +9169,69 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wayland-backend"
-version = "0.3.12"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa75f400b7f719bcd68b3f47cd939ba654cedeef690f486db71331eec4c6a406"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -3621,12 +9239,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.12"
+version = "0.31.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
+checksum = "ab51d9f7c071abeee76007e2b742499e535148035bb835f97aaed1338cf516c3"
 dependencies = [
- "bitflags 2.10.0",
- "rustix 1.1.3",
+ "bitflags 2.11.0",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -3637,29 +9255,29 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cursor-icon",
  "wayland-backend",
 ]
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.12"
+version = "0.31.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5864c4b5b6064b06b1e8b74ead4a98a6c45a285fe7a0e784d24735f011fdb078"
+checksum = "4b3298683470fbdc6ca40151dfc48c8f2fd4c41a26e13042f801f85002384091"
 dependencies = [
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "wayland-client",
  "xcursor",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.10"
+version = "0.32.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
+checksum = "b23b5df31ceff1328f06ac607591d5ba360cf58f90c8fad4ac8d3a55a3c4aec7"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -3671,7 +9289,7 @@ version = "20250721.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -3680,11 +9298,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-misc"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791c58fdeec5406aa37169dd815327d1e47f334219b523444bc26d70ceb4c34e"
+checksum = "429b99200febaf95d4f4e46deff6fe4382bcff3280ee16a41cf887b3c3364984"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -3693,11 +9311,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9597cdf02cf0c34cd5823786dce6b5ae8598f05c2daf5621b6e178d4f7345f3"
+checksum = "78248e4cc0eff8163370ba5c158630dcae1f3497a586b826eca2ef5f348d6235"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -3706,9 +9324,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.8"
+version = "0.31.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
+checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -3717,9 +9335,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.8"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
+checksum = "374f6b70e8e0d6bf9461a32988fd553b59ff630964924dad6e4a4eb6bd538d17"
 dependencies = [
  "dlib",
  "log",
@@ -3729,19 +9347,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3753,19 +9361,130 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
 dependencies = [
- "phf",
- "phf_codegen",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
  "string_cache 0.8.9",
- "string_cache_codegen",
+ "string_cache_codegen 0.5.4",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
+]
+
+[[package]]
+name = "webdriver"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d53921e1bef27512fa358179c9a22428d55778d2c2ae3c5c37a52b82ce6e92"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "cookie 0.16.2",
+ "http 0.2.12",
+ "icu_segmenter 1.5.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "url",
+ "warp",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3e3b5f5e80bc89f30ce8d0343bf4e5f12341c51f3e26cbeecbc7c85443e85b"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webrender"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a591c25221a9f8ac2ad7754659b283d912cee6c8424f0fa3777aabed3be91c16"
+dependencies = [
+ "allocator-api2",
+ "bincode",
+ "bitflags 2.11.0",
+ "build-parallel",
+ "byteorder",
+ "derive_more",
+ "etagere",
+ "euclid",
+ "gleam",
+ "glslopt",
+ "lazy_static",
+ "log",
+ "malloc_size_of_derive",
+ "num-traits",
+ "peek-poke",
+ "plane-split",
+ "rayon",
+ "ron",
+ "rustc-hash 2.1.2",
+ "serde",
+ "smallvec",
+ "svg_fmt",
+ "topological-sort",
+ "tracy-rs",
+ "webrender_api",
+ "webrender_build",
+ "wr_glyph_rasterizer",
+ "wr_malloc_size_of",
+ "zeitstempel",
+]
+
+[[package]]
+name = "webrender_api"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb206f613b4635881065a2ff4670e656edc904af0b8729c51ce1196679fd1b6d"
+dependencies = [
+ "app_units",
+ "bitflags 2.11.0",
+ "byteorder",
+ "crossbeam-channel",
+ "euclid",
+ "malloc_size_of_derive",
+ "peek-poke",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "wr_malloc_size_of",
+ "zeitstempel",
+]
+
+[[package]]
+name = "webrender_build"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6165a81201892371061250bd6f08ede9ed7279842fedc4033f48582a789068"
+dependencies = [
+ "bitflags 2.11.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -3828,6 +9547,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3835,9 +9589,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3848,7 +9613,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3859,8 +9624,14 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -3869,12 +9640,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3883,7 +9682,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3928,7 +9727,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3968,7 +9767,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -3977,6 +9776,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4119,11 +9927,20 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wio"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -4131,6 +9948,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "wpe-jsc"
@@ -4213,16 +10118,123 @@ dependencies = [
 ]
 
 [[package]]
+name = "wr_glyph_rasterizer"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4fcffa889d25131fc7c6ec8a558aa7c78d6030eaa17e31695c172adcc4eb0b"
+dependencies = [
+ "core-foundation 0.9.4",
+ "core-graphics",
+ "core-text",
+ "dwrote",
+ "euclid",
+ "freetype",
+ "lazy_static",
+ "libc",
+ "log",
+ "malloc_size_of_derive",
+ "objc",
+ "rayon",
+ "rustc-hash 2.1.2",
+ "serde",
+ "smallvec",
+ "tracy-rs",
+ "webrender_api",
+ "wr_malloc_size_of",
+]
+
+[[package]]
+name = "wr_malloc_size_of"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482308b684f11723b200a32808094bb460b5ac4840903ccbcb78ad92a6354a1f"
+dependencies = [
+ "app_units",
+ "euclid",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "xcursor"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xi-unicode"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 
 [[package]]
 name = "xkbcommon"
@@ -4236,12 +10248,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.11.0",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
 name = "xkbcommon-sys"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7dbb61bc8fd714a64f750e9c259952f079afe701256dd2118602c0ae15c90"
 dependencies = [
- "bindgen",
+ "bindgen 0.63.0",
  "libc",
  "pkg-config",
 ]
@@ -4256,6 +10281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
+
+[[package]]
 name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4268,7 +10299,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee3f1e41afb31a75aef076563b0ad3ecc24f5bd9d12a72b132222664eb76b494"
 dependencies = [
  "log",
- "markup5ever",
+ "markup5ever 0.35.0",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab627f34ff61b80d756180d556f9c68801d836d271b3b8c094504ceca69d221"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
+]
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yeslogic-fontconfig-sys"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive 0.7.5",
+ "zerofrom",
 ]
 
 [[package]]
@@ -4278,8 +10354,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
  "stable_deref_trait",
- "yoke-derive",
+ "yoke-derive 0.8.1",
  "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -4290,28 +10378,49 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.31"
+name = "yuv"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "47d3a7e2cda3061858987ee2fb028f61695f5ee13f9490d75be6c3900df9a4ea"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "zeitstempel"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94652f036694517fa67509942c3b60a51a19e1cd9cfd0f456eeb830ae8798d3d"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "once_cell",
+ "winapi",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4331,7 +10440,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4340,6 +10449,31 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb594dd55d87335c5f60177cee24f19457a5ec10a065e0a3014722ad252d0a1f"
+dependencies = [
+ "displaydoc",
+ "yoke 0.7.5",
+ "zerofrom",
+]
 
 [[package]]
 name = "zerotrie"
@@ -4348,8 +10482,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
- "yoke",
+ "yoke 0.8.1",
  "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke 0.7.5",
+ "zerofrom",
+ "zerovec-derive 0.10.3",
 ]
 
 [[package]]
@@ -4358,9 +10503,21 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
- "yoke",
+ "serde",
+ "yoke 0.8.1",
  "zerofrom",
- "zerovec-derive",
+ "zerovec-derive 0.11.2",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4371,26 +10528,78 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.7"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9211a9f64b825911bdf0240f58b7a8dac217fe260fc61f080a07f61372fbd5"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"
-version = "0.5.0"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111f7d9820f05fd715df3144e254d6fc02ee4088b0644c0ffd0efc9e6d9d2773"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.7"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d915729b0e7d5fe35c2f294c5dc10b30207cc637920e5b59077bfa3da63f28"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
- "zune-core",
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec5f41c76397b7da451efd19915684f727d7e1d516384ca6bd0ec43ec94de23c"
+dependencies = [
+ "zune-core 0.5.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,19 @@ rust-version.workspace = true
 edition.workspace = true
 
 [features]
-default = []
+default = ["servo", "webkit"]
 profiling = ["dep:profiling", "dep:puffin_http"]
+servo = [
+    "dep:dpi",
+    "dep:euclid",
+    "dep:keyboard-types",
+    "dep:servo",
+    "dep:surfman",
+]
+webkit = [
+    "dep:wpe-platform",
+    "dep:wpe-webkit",
+]
 
 [workspace]
 members = [
@@ -48,25 +59,30 @@ xkbcommon-sys = "1.4.1"
 
 # Dependencies only used by the binary.
 [dependencies]
-bitflags = "2.5.0"
+bitflags = "2.11.0"
 chrono = "0.4.39"
 clap = { version = "4.5.39", features = ["derive"] }
 configory = { version = "0.6.0", features = ["log", "docgen"] }
 dashmap = "6.0.1"
 dirs = "6.0.0"
+dpi = { version = "0.1.2", optional = true }
 drm = "0.14.0"
+euclid = { version = "0.22.13", optional = true }
 funq = { path = "./funq" }
 gio.workspace = true
 glib.workspace = true
 glutin = { version = "0.32.1", default-features = false, features = ["wayland"] }
 indexmap = "2.2.6"
+keyboard-types = { version = "0.8.3", optional = true }
 libc.workspace = true
 librsvg = "2.61.0"
 pangocairo = "0.21.1"
+servo = { git = "https://github.com/chrisduerr/servo", rev = "36c07f4e4f0fbbd775d68171a3767053e8a24b5e", optional = true }
+surfman = { version = "0.12.0", optional = true }
 profiling = { version = "1.0.14", optional = true, features = ["profile-with-puffin"] }
 puffin_http = { version = "0.16.0", optional = true }
 raw-window-handle = "0.6.0"
-rusqlite = { version = "0.38.0", features = ["uuid", "chrono"] }
+rusqlite = { version = "0.37.0", features = ["uuid", "chrono"] }
 rustix.workspace = true
 serde = { version = "1.0.219", features = ["derive"] }
 smallvec = "1.13.2"
@@ -75,13 +91,19 @@ thiserror = "2.0.3"
 toml = "0.9.5"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-uuid = { version = "1.11.0", features = ["v4"] }
+url = "2.5.8"
+uuid = { version = "1.23.0", features = ["v4"] }
 wayland-backend = { version = "0.3.8", features = ["client_system"] }
-wpe-platform = { path = "./wpe-platform" }
-wpe-webkit = { path = "./wpe-webkit" }
+wpe-platform = { path = "./wpe-platform", optional = true }
+wpe-webkit = { path = "./wpe-webkit", optional = true }
+xkbcommon-dl = "0.4.2"
 
 [build-dependencies]
 gl_generator = "0.14.0"
 
 [dev-dependencies]
-reqwest = { version = "0.13.1", default-features = false, features = ["default-tls", "blocking"] }
+tempfile = "3.27.0"
+
+[patch.crates-io]
+glslopt = { git = "https://github.com/chrisduerr/glslopt-rs", rev = "c3c9457b752729f90761352e6c1e70e051430dd6" }
+keyboard-types = { git = "https://github.com/chrisduerr/keyboard-types", rev = "03b47d33d345b35671076bcd8ce4533250997c72" }

--- a/docs/config.md
+++ b/docs/config.md
@@ -3,7 +3,7 @@
 ## Syntax
 
 Kumo's configuration file uses the TOML format. The format's specification
-can be found at _https://toml.io/en/v1.0.0_.
+can be found at _<https://toml.io/en/v1.0.0>_.
 
 ## Location
 
@@ -56,3 +56,11 @@ This section documents the `[input]` table.
 |long_press|Minimum time before a tap is considered a long-press|integer (milliseconds)|`300`|
 |velocity_interval|Milliseconds per velocity tick|integer|`30`|
 |velocity_friction|Percentage of velocity retained each tick|float|`0.85`|
+
+### engine
+
+This section documents the `[engine]` table.
+
+|Name|Description|Type|Default|
+|-|-|-|-|
+|default|Default browser engine|"WebKit" \| "Servo"|`WebKit`|

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use serde::de::Visitor;
 use serde::{Deserialize, Deserializer};
 use tracing::{error, info};
 
+use crate::engine::EngineType;
 use crate::{Error, State};
 
 #[funq::callbacks(State)]
@@ -57,7 +58,7 @@ pub fn init_config(queue: MtQueueHandle<State>) -> Result<Manager<ConfigEventHan
 /// ## Syntax
 ///
 /// Kumo's configuration file uses the TOML format. The format's specification
-/// can be found at _https://toml.io/en/v1.0.0_.
+/// can be found at _<https://toml.io/en/v1.0.0>_.
 ///
 /// ## Location
 ///
@@ -76,6 +77,8 @@ pub struct Config {
     pub search: Search,
     /// This section documents the `[input]` table.
     pub input: Input,
+    /// This section documents the `[engine]` table.
+    pub engine: Engine,
 
     /// Incremental config ID, to track changes.
     #[serde(skip)]
@@ -202,6 +205,24 @@ impl Default for Input {
             velocity_interval: 30,
             velocity_friction: 0.85,
             max_tap_distance: 400.,
+        }
+    }
+}
+
+#[derive(Docgen, Deserialize, Debug)]
+#[serde(default, deny_unknown_fields)]
+pub struct Engine {
+    /// Default browser engine.
+    pub default: EngineType,
+}
+
+impl Default for Engine {
+    fn default() -> Self {
+        Self {
+            #[cfg(feature = "webkit")]
+            default: EngineType::WebKit,
+            #[cfg(not(feature = "webkit"))]
+            default: EngineType::Servo,
         }
     }
 }
@@ -451,6 +472,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg(feature = "webkit")]
     #[test]
     fn config_docs() {
         let mut formatter = Markdown::new();

--- a/src/engine/dummy.rs
+++ b/src/engine/dummy.rs
@@ -1,0 +1,148 @@
+//! No-op engine implementation.
+
+use std::any::Any;
+use std::borrow::Cow;
+
+use smithay_client_toolkit::reexports::client::protocol::wl_surface::WlSurface;
+use smithay_client_toolkit::seat::keyboard::{Keysym, Modifiers};
+use smithay_client_toolkit::seat::pointer::AxisScroll;
+
+use crate::engine::{Engine, EngineId, EngineType};
+use crate::ui::overlay::option_menu::OptionMenuId;
+use crate::window::TextInputChange;
+use crate::{Position, Size};
+
+/// Dummy engine.
+///
+/// This no-op engine can be used as a placeholder for a real engine.
+pub struct DummyEngine {
+    id: EngineId,
+
+    surface: WlSurface,
+
+    size: Size,
+    scale: f64,
+}
+
+impl DummyEngine {
+    pub fn new(id: EngineId, surface: WlSurface) -> Self {
+        Self { surface, id, scale: 1., size: Default::default() }
+    }
+}
+
+impl Engine for DummyEngine {
+    fn id(&self) -> EngineId {
+        self.id
+    }
+
+    fn engine_type(&self) -> EngineType {
+        EngineType::Dummy
+    }
+
+    fn dirty(&mut self) -> bool {
+        false
+    }
+
+    fn draw(&mut self) -> bool {
+        self.surface.attach(None, 0, 0);
+        false
+    }
+
+    fn buffer_size(&self) -> Size {
+        self.size * self.scale
+    }
+
+    fn set_size(&mut self, size: Size) {
+        self.size = size;
+    }
+
+    fn set_scale(&mut self, scale: f64) {
+        self.scale = scale;
+    }
+
+    fn press_key(&mut self, _time: u32, _raw: u32, _keysym: Keysym, _modifiers: Modifiers) {}
+
+    fn release_key(&mut self, _time: u32, _raw: u32, _keysym: Keysym, _modifiers: Modifiers) {}
+
+    fn pointer_axis(
+        &mut self,
+        _time: u32,
+        _position: Position<f64>,
+        _horizontal: AxisScroll,
+        _vertical: AxisScroll,
+        _modifiers: Modifiers,
+    ) {
+    }
+
+    fn pointer_button(
+        &mut self,
+        _time: u32,
+        _position: Position<f64>,
+        _button: u32,
+        _down: bool,
+        _modifiers: Modifiers,
+    ) {
+    }
+
+    fn pointer_motion(&mut self, _time: u32, _position: Position<f64>, _modifiers: Modifiers) {}
+
+    fn touch_up(&mut self, _time: u32, _id: i32, _position: Position<f64>, _modifiers: Modifiers) {}
+
+    fn touch_down(
+        &mut self,
+        _time: u32,
+        _id: i32,
+        _position: Position<f64>,
+        _modifiers: Modifiers,
+    ) {
+    }
+
+    fn touch_motion(
+        &mut self,
+        _time: u32,
+        _id: i32,
+        _position: Position<f64>,
+        _modifiers: Modifiers,
+    ) {
+    }
+
+    fn reload(&mut self) {}
+
+    fn load_uri(&mut self, _uri: &str) {}
+
+    fn load_prev(&mut self) {}
+
+    fn has_prev(&self) -> bool {
+        false
+    }
+
+    fn uri(&self) -> Cow<'_, str> {
+        Cow::Borrowed("")
+    }
+
+    fn title(&self) -> Cow<'_, str> {
+        Cow::Borrowed("")
+    }
+
+    fn text_input_state(&mut self) -> TextInputChange {
+        TextInputChange::Disabled
+    }
+
+    fn delete_surrounding_text(&mut self, _before_length: u32, _after_length: u32) {}
+
+    fn commit_string(&mut self, _text: String) {}
+
+    fn set_preedit_string(&mut self, _text: String, _cursor_begin: i32, _cursor_end: i32) {}
+
+    fn clear_focus(&mut self) {}
+
+    fn submit_option_menu(&mut self, _menu_id: OptionMenuId, _index: usize) {}
+
+    fn close_option_menu(&mut self, _menu_id: Option<OptionMenuId>) {}
+
+    fn set_fullscreen(&mut self, _fullscreen: bool) {}
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,20 +1,41 @@
 use std::any::Any;
 use std::borrow::Cow;
+use std::cell::{Cell, RefCell, RefMut};
+use std::rc::Rc;
+#[cfg(feature = "servo")]
+use std::sync::atomic::AtomicU32;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+#[cfg(feature = "servo")]
+use ::servo::ContextMenuElementInformationFlags;
+use bitflags::bitflags;
+use configory::docgen::Docgen;
+use funq::MtQueueHandle;
+use rusqlite::types::{FromSql, FromSqlError, ToSql, ToSqlOutput, ValueRef};
+use serde::Deserialize;
 use smithay_client_toolkit::dmabuf::DmabufFeedback;
 use smithay_client_toolkit::reexports::client::protocol::wl_buffer::WlBuffer;
 use smithay_client_toolkit::reexports::client::protocol::wl_region::WlRegion;
-use smithay_client_toolkit::reexports::client::protocol::wl_surface::WlSurface;
 use smithay_client_toolkit::seat::keyboard::{Keysym, Modifiers};
 use smithay_client_toolkit::seat::pointer::AxisScroll;
+use url::Url;
 use uuid::Uuid;
+#[cfg(feature = "webkit")]
+use wpe_webkit::HitTestResultContext;
 
-use crate::ui::overlay::downloads::{Download, DownloadId};
-use crate::ui::overlay::option_menu::OptionMenuId;
-use crate::window::TextInputChange;
+use crate::gl::types::GLenum;
+use crate::storage::cookie_whitelist::CookieWhitelist;
+#[cfg(feature = "webkit")]
+use crate::ui::overlay::downloads::Download;
+use crate::ui::overlay::downloads::DownloadId;
+use crate::ui::overlay::option_menu::{OptionMenuId, OptionMenuItem};
+use crate::window::{PasteTarget, TextInputChange, WindowHandler};
 use crate::{KeyboardFocus, Position, Size, State, WindowId};
 
+pub mod dummy;
+#[cfg(feature = "servo")]
+pub mod servo;
+#[cfg(feature = "webkit")]
 pub mod webkit;
 
 // Constants for the default tab group.
@@ -29,15 +50,21 @@ pub trait Engine {
     /// Get the engine's unique ID.
     fn id(&self) -> EngineId;
 
+    /// Get this engine's type.
+    fn engine_type(&self) -> EngineType;
+
     /// Check if the engine requires a redraw.
     ///
     /// This will always be called **before** any rendering is done.
     fn dirty(&mut self) -> bool;
 
-    /// Attach the engine's buffer to the supplied surface.
+    /// Set whether the browser engine is currently visible for rendering.
+    fn set_visible(&mut self, _visible: bool) {}
+
+    /// Draw the engine's content to its surface.
     ///
-    /// Should return `false` when no surface was attached.
-    fn attach_buffer(&mut self, surface: &WlSurface) -> bool;
+    /// Should return `false` if no buffer was attached to the surface.
+    fn draw(&mut self) -> bool;
 
     /// Get the Wayland buffer's current physical size.
     fn buffer_size(&self) -> Size;
@@ -102,10 +129,10 @@ pub trait Engine {
     fn pointer_motion(&mut self, time: u32, position: Position<f64>, modifiers: Modifiers);
 
     /// Handle pointer enter.
-    fn pointer_enter(&mut self, position: Position<f64>, modifiers: Modifiers);
+    fn pointer_enter(&mut self, _position: Position<f64>, _modifiers: Modifiers) {}
 
     /// Handle pointer leave.
-    fn pointer_leave(&mut self, position: Position<f64>, modifiers: Modifiers);
+    fn pointer_leave(&mut self, _position: Position<f64>, _modifiers: Modifiers) {}
 
     /// Handle touch press.
     fn touch_up(&mut self, time: u32, id: i32, position: Position<f64>, modifiers: Modifiers);
@@ -115,6 +142,9 @@ pub trait Engine {
 
     /// Handle touch motion.
     fn touch_motion(&mut self, time: u32, id: i32, position: Position<f64>, modifiers: Modifiers);
+
+    /// Reload the current page.
+    fn reload(&mut self);
 
     /// Load a new page.
     fn load_uri(&mut self, uri: &str);
@@ -132,7 +162,7 @@ pub trait Engine {
     fn title(&self) -> Cow<'_, str>;
 
     /// Get IME text_input state.
-    fn text_input_state(&self) -> TextInputChange;
+    fn text_input_state(&mut self) -> TextInputChange;
 
     /// Delete text around the current cursor position.
     fn delete_surrounding_text(&mut self, before_length: u32, after_length: u32);
@@ -142,9 +172,6 @@ pub trait Engine {
 
     /// Set preedit text at the current cursor position.
     fn set_preedit_string(&mut self, text: String, cursor_begin: i32, cursor_end: i32);
-
-    /// Paste clipboard text.
-    fn paste(&mut self, text: String);
 
     /// Clear engine focus.
     fn clear_focus(&mut self);
@@ -159,17 +186,23 @@ pub trait Engine {
     fn set_fullscreen(&mut self, fullscreen: bool);
 
     /// Get a serialized version of the current session.
-    fn session(&self) -> Vec<u8>;
+    fn session(&self) -> Vec<u8> {
+        Vec::new()
+    }
 
     /// Restore a browser session.
-    fn restore_session(&self, session: Vec<u8>);
+    fn restore_session(&self, _session: Vec<u8>) {}
 
     /// Get favicon for the current page.
     fn favicon(&self) -> Option<Favicon> {
         None
     }
 
+    // Servo currently does not support any way to cheaply identify favicons:
+    // <https://github.com/servo/servo/issues/43159>
+    //
     /// Get the current favicon resource URI.
+    #[cfg(feature = "webkit")]
     fn favicon_uri(&self) -> Option<glib::GString> {
         None
     }
@@ -205,6 +238,13 @@ pub trait EngineHandler {
     /// Update current URI for an engine.
     fn set_engine_uri(&mut self, engine_id: EngineId, uri: String, update_history: bool);
 
+    /// Reload a page.
+    fn reload(&mut self, engine_id: EngineId);
+
+    /// Reload tab in a different browser engine.
+    #[cfg(all(feature = "servo", feature = "webkit"))]
+    fn switch_engine(&mut self, engine_id: EngineId, engine_type: EngineType);
+
     /// Update current title for an engine.
     fn set_engine_title(&mut self, engine_id: EngineId, title: String);
 
@@ -235,21 +275,26 @@ pub trait EngineHandler {
     fn update_favicon(&mut self, engine_id: EngineId);
 
     /// Add a new download.
+    #[cfg(feature = "webkit")]
     fn add_download(&mut self, window_id: WindowId, download: Download);
 
     /// Update a download's progress.
     ///
     /// A progress value of `None` indicates that the download has failed and
     /// will not make any further progress.
+    #[cfg(feature = "webkit")]
     fn set_download_progress(&mut self, download_id: DownloadId, progress: Option<u8>);
 
     /// Start page text search.
+    #[cfg(feature = "webkit")]
     fn start_search(&mut self, engine_id: EngineId);
 
     /// Update number of text search matches.
+    #[cfg(feature = "webkit")]
     fn set_search_match_count(&mut self, engine_id: EngineId, count: usize);
 
     /// Set whether a tab is playing audio.
+    #[cfg(feature = "webkit")]
     fn set_audio_playing(&mut self, engine_id: EngineId, playing: bool);
 }
 
@@ -258,6 +303,29 @@ impl EngineHandler for State {
         if let Some(window) = self.windows.get_mut(&engine_id.window_id()) {
             window.set_engine_uri(engine_id, uri, update_history);
         }
+    }
+
+    fn reload(&mut self, engine_id: EngineId) {
+        let window = match self.windows.get_mut(&engine_id.window_id()) {
+            Some(window) => window,
+            None => return,
+        };
+        let engine = match window.tab_mut(engine_id) {
+            Some(engine) => engine,
+            None => return,
+        };
+
+        engine.reload();
+    }
+
+    #[cfg(all(feature = "servo", feature = "webkit"))]
+    fn switch_engine(&mut self, engine_id: EngineId, engine_type: EngineType) {
+        let window = match self.windows.get_mut(&engine_id.window_id()) {
+            Some(window) => window,
+            None => return,
+        };
+
+        window.switch_engine(engine_id, engine_type);
     }
 
     fn set_engine_title(&mut self, engine_id: EngineId, title: String) {
@@ -284,10 +352,7 @@ impl EngineHandler for State {
             None => return,
         };
 
-        let tab_id = window.add_tab_from_engine(false, false, engine_id.group_id(), engine_id);
-        if let Some(engine) = window.tab_mut(tab_id) {
-            engine.load_uri(&uri);
-        }
+        window.add_tab_from_engine(false, false, engine_id.group_id(), Some(&uri), engine_id);
     }
 
     fn open_in_window(&mut self, parent: EngineId, uri: String) {
@@ -304,15 +369,12 @@ impl EngineHandler for State {
         if parent_ephemeral {
             let group_id = window.create_tab_group(None, true);
             window.set_ephemeral_mode(group_id, true);
-            window.add_tab(false, true, group_id);
+            window.add_tab(false, true, group_id, Some(&uri));
         } else {
-            window.add_tab(false, true, NO_GROUP_ID);
+            window.add_tab(false, true, NO_GROUP_ID, Some(&uri));
         }
 
         window.set_keyboard_focus(KeyboardFocus::None);
-        if let Some(engine) = window.active_tab_mut() {
-            engine.load_uri(&uri);
-        }
     }
 
     fn add_cookie_exception(&mut self, host: String) {
@@ -329,30 +391,35 @@ impl EngineHandler for State {
         }
     }
 
+    #[cfg(feature = "webkit")]
     fn add_download(&mut self, window_id: WindowId, download: Download) {
         if let Some(window) = self.windows.get_mut(&window_id) {
             window.add_download(download);
         }
     }
 
+    #[cfg(feature = "webkit")]
     fn set_download_progress(&mut self, download_id: DownloadId, progress: Option<u8>) {
         if let Some(window) = self.windows.get_mut(&download_id.window_id()) {
             window.set_download_progress(download_id, progress);
         }
     }
 
+    #[cfg(feature = "webkit")]
     fn start_search(&mut self, engine_id: EngineId) {
         if let Some(window) = self.windows.get_mut(&engine_id.window_id()) {
             window.start_search(engine_id);
         }
     }
 
+    #[cfg(feature = "webkit")]
     fn set_search_match_count(&mut self, engine_id: EngineId, count: usize) {
         if let Some(window) = self.windows.get_mut(&engine_id.window_id()) {
             window.set_search_match_count(engine_id, count);
         }
     }
 
+    #[cfg(feature = "webkit")]
     fn set_audio_playing(&mut self, engine_id: EngineId, playing: bool) {
         if let Some(window) = self.windows.get_mut(&engine_id.window_id()) {
             window.set_audio_playing(engine_id, playing);
@@ -445,8 +512,375 @@ impl Default for GroupId {
 /// Page favicon data.
 #[derive(Clone, Debug)]
 pub struct Favicon {
-    pub resource_uri: glib::GString,
+    pub id: FaviconId,
     pub bytes: glib::Bytes,
     pub width: usize,
     pub height: usize,
+    pub format: GLenum,
+}
+
+/// Unique identifier for a Servo favicon.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum FaviconId {
+    #[cfg(feature = "webkit")]
+    WebKit(glib::GString),
+    #[cfg(feature = "servo")]
+    Servo(u32),
+}
+
+impl FaviconId {
+    #[cfg(feature = "servo")]
+    pub fn new_servo() -> Self {
+        static NEXT_SERVO_FAVICON_ID: AtomicU32 = AtomicU32::new(0);
+        Self::Servo(NEXT_SERVO_FAVICON_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+/// Browser engine context menu.
+#[derive(Debug)]
+struct ContextMenu {
+    target_flags: ContextMenuTargetFlags,
+    has_cookie_exception: bool,
+    target_url: Option<String>,
+    #[cfg(feature = "webkit")]
+    engine_type: EngineType,
+    host: Option<String>,
+}
+
+impl ContextMenu {
+    fn new(
+        #[cfg(feature = "webkit")] engine_type: EngineType,
+        target_flags: ContextMenuTargetFlags,
+        cookie_whitelist: &CookieWhitelist,
+        engine_url: &str,
+        target_url: Option<String>,
+    ) -> Self {
+        let (host, has_cookie_exception) = if target_flags.is_empty()
+            && let Some(host) = Url::parse(engine_url).ok().as_ref().and_then(|url| url.host_str())
+        {
+            let has_cookie_exception = cookie_whitelist.contains(host);
+            (Some(host.into()), has_cookie_exception)
+        } else {
+            (None, false)
+        };
+
+        Self {
+            has_cookie_exception,
+            target_flags,
+            #[cfg(feature = "webkit")]
+            engine_type,
+            target_url,
+            host,
+        }
+    }
+
+    /// Number of items in the menu.
+    fn len(&self) -> u32 {
+        let mut n_items = 0;
+
+        // Only show these entries without any targeted element.
+        if self.target_flags.is_empty() {
+            #[cfg(feature = "webkit")]
+            if self.engine_type == EngineType::WebKit {
+                n_items += 1;
+            }
+            n_items += 1;
+        }
+
+        n_items += 1;
+        #[cfg(all(feature = "servo", feature = "webkit"))]
+        {
+            n_items += 1;
+        }
+
+        if self
+            .target_flags
+            .intersects(ContextMenuTargetFlags::LINK | ContextMenuTargetFlags::MEDIA)
+        {
+            n_items += 3;
+        }
+
+        if self.target_flags.contains(ContextMenuTargetFlags::EDITABLE) {
+            n_items += 1;
+        }
+
+        n_items
+    }
+
+    /// Get option menu items for this menu.
+    fn items(&self) -> Vec<OptionMenuItem> {
+        let mut items = Vec::new();
+        for i in 0..self.len() {
+            if let Some(item) = self.item(i) {
+                items.push(OptionMenuItem {
+                    description: String::new(),
+                    label: item.label().into(),
+                    disabled: false,
+                    selected: false,
+                });
+            }
+        }
+        items
+    }
+
+    /// Get the item at the specified index.
+    #[allow(clippy::single_match)]
+    fn item(&self, mut index: u32) -> Option<ContextMenuItem> {
+        // Only show these entries without any targeted element.
+        if self.target_flags.is_empty() {
+            match index {
+                0 if self.has_cookie_exception => {
+                    return Some(ContextMenuItem::RemoveCookieException);
+                },
+                0 => return Some(ContextMenuItem::AddCookieException),
+                #[cfg(feature = "webkit")]
+                1 if self.engine_type == EngineType::WebKit => {
+                    return Some(ContextMenuItem::Search);
+                },
+                _ => (),
+            }
+            #[cfg(feature = "webkit")]
+            if self.engine_type == EngineType::WebKit {
+                index -= 1;
+            }
+            index -= 1;
+        }
+
+        match index {
+            0 => return Some(ContextMenuItem::Reload),
+            #[cfg(all(feature = "servo", feature = "webkit"))]
+            1 => match self.engine_type {
+                EngineType::Servo => return Some(ContextMenuItem::ReloadInWebKit),
+                EngineType::WebKit => return Some(ContextMenuItem::ReloadInServo),
+                EngineType::Dummy => unreachable!("dummy engine context menu"),
+            },
+            _ => (),
+        }
+        index -= 1;
+        #[cfg(all(feature = "servo", feature = "webkit"))]
+        {
+            index -= 1;
+        }
+
+        if self
+            .target_flags
+            .intersects(ContextMenuTargetFlags::LINK | ContextMenuTargetFlags::MEDIA)
+        {
+            match index {
+                0 => return Some(ContextMenuItem::CopyLink),
+                1 => return Some(ContextMenuItem::OpenInNewWindow),
+                2 => return Some(ContextMenuItem::OpenInNewTab),
+                _ => (),
+            }
+            index -= 3;
+        }
+
+        if self.target_flags.contains(ContextMenuTargetFlags::EDITABLE) {
+            match index {
+                0 => return Some(ContextMenuItem::Paste),
+                _ => (),
+            }
+            // index -= 1;
+        }
+
+        None
+    }
+
+    /// Activate item at the specified position.
+    fn activate_item(&self, mut queue: MtQueueHandle<State>, engine_id: EngineId, index: u32) {
+        match self.item(index) {
+            Some(ContextMenuItem::AddCookieException) => {
+                if let Some(host) = &self.host {
+                    queue.add_cookie_exception(host.to_string());
+                }
+            },
+            Some(ContextMenuItem::RemoveCookieException) => {
+                if let Some(host) = &self.host {
+                    queue.remove_cookie_exception(host.to_string());
+                }
+            },
+            #[cfg(feature = "webkit")]
+            Some(ContextMenuItem::Search) => queue.start_search(engine_id),
+            #[cfg(all(feature = "servo", feature = "webkit"))]
+            Some(ContextMenuItem::ReloadInWebKit) => {
+                queue.switch_engine(engine_id, EngineType::WebKit)
+            },
+            #[cfg(all(feature = "servo", feature = "webkit"))]
+            Some(ContextMenuItem::ReloadInServo) => {
+                queue.switch_engine(engine_id, EngineType::Servo)
+            },
+            Some(ContextMenuItem::Reload) => queue.reload(engine_id),
+            Some(ContextMenuItem::OpenInNewTab) => {
+                if let Some(url) = self.url() {
+                    queue.open_in_tab(engine_id, url.into());
+                }
+            },
+            Some(ContextMenuItem::OpenInNewWindow) => {
+                if let Some(url) = self.url() {
+                    queue.open_in_window(engine_id, url.into());
+                }
+            },
+            Some(ContextMenuItem::CopyLink) => {
+                if let Some(url) = self.url() {
+                    queue.set_clipboard(url.into());
+                }
+            },
+            Some(ContextMenuItem::Paste) => queue.request_paste(PasteTarget::Browser(engine_id)),
+            None => (),
+        }
+    }
+
+    /// Get URL for the context menu's target resource.
+    fn url(&self) -> Option<&str> {
+        self.target_url.as_deref()
+    }
+}
+
+bitflags! {
+    /// Properties of the item a context menu was created for.
+    #[derive(Copy, Clone, Debug)]
+    pub struct ContextMenuTargetFlags: u8 {
+        const LINK = 1 << 1;
+        const MEDIA = 1 << 2;
+        const EDITABLE = 1 << 3;
+    }
+}
+
+#[cfg(feature = "webkit")]
+impl From<HitTestResultContext> for ContextMenuTargetFlags {
+    fn from(context: HitTestResultContext) -> Self {
+        let mut flags = ContextMenuTargetFlags::empty();
+        flags.set(
+            ContextMenuTargetFlags::MEDIA,
+            context.contains(HitTestResultContext::MEDIA | HitTestResultContext::IMAGE),
+        );
+        flags.set(
+            ContextMenuTargetFlags::EDITABLE,
+            context.contains(HitTestResultContext::EDITABLE),
+        );
+        flags.set(ContextMenuTargetFlags::LINK, context.contains(HitTestResultContext::LINK));
+        flags
+    }
+}
+
+#[cfg(feature = "servo")]
+impl From<ContextMenuElementInformationFlags> for ContextMenuTargetFlags {
+    fn from(context_flags: ContextMenuElementInformationFlags) -> Self {
+        let mut flags = ContextMenuTargetFlags::empty();
+        flags.set(
+            ContextMenuTargetFlags::MEDIA,
+            context_flags.contains(ContextMenuElementInformationFlags::Image),
+        );
+        flags.set(
+            ContextMenuTargetFlags::EDITABLE,
+            context_flags.contains(ContextMenuElementInformationFlags::EditableText),
+        );
+        flags.set(
+            ContextMenuTargetFlags::LINK,
+            context_flags.contains(ContextMenuElementInformationFlags::Link),
+        );
+        flags
+    }
+}
+
+/// Custom context menu item based on a hit test.
+#[derive(Debug)]
+enum ContextMenuItem {
+    AddCookieException,
+    RemoveCookieException,
+    #[cfg(all(feature = "servo", feature = "webkit"))]
+    ReloadInWebKit,
+    #[cfg(all(feature = "servo", feature = "webkit"))]
+    ReloadInServo,
+    Reload,
+    OpenInNewTab,
+    OpenInNewWindow,
+    CopyLink,
+    Paste,
+    #[cfg(feature = "webkit")]
+    Search,
+}
+
+impl ContextMenuItem {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::AddCookieException => "Add Cookie Exception",
+            Self::RemoveCookieException => "Remove Cookie Exception",
+            #[cfg(all(feature = "servo", feature = "webkit"))]
+            Self::ReloadInWebKit => "Reload in WebKit",
+            #[cfg(all(feature = "servo", feature = "webkit"))]
+            Self::ReloadInServo => "Reload in Servo",
+            Self::Reload => "Reload",
+            Self::OpenInNewTab => "Open in New Tab",
+            Self::OpenInNewWindow => "Open in New Window",
+            Self::CopyLink => "Copy Link",
+            Self::Paste => "Paste",
+            #[cfg(feature = "webkit")]
+            Self::Search => "Search Page",
+        }
+    }
+}
+
+/// Browser engine backend.
+#[derive(Docgen, Deserialize, PartialEq, Eq, Copy, Clone, Debug)]
+#[docgen(doc_type = "\"WebKit\" \\| \"Servo\"")]
+pub enum EngineType {
+    WebKit,
+    Servo,
+    #[serde(skip)]
+    Dummy,
+}
+
+impl FromSql for EngineType {
+    fn column_result(value: ValueRef<'_>) -> Result<Self, FromSqlError> {
+        value.as_str().and_then(|s| match s {
+            "webkit" => Ok(Self::WebKit),
+            "servo" => Ok(Self::Servo),
+            _ => Err(FromSqlError::InvalidType),
+        })
+    }
+}
+
+impl ToSql for EngineType {
+    fn to_sql(&self) -> Result<ToSqlOutput<'_>, rusqlite::Error> {
+        let s = match self {
+            Self::Dummy => unreachable!("dummy engine sql write"),
+            Self::WebKit => "webkit",
+            Self::Servo => "servo",
+        };
+        Ok(ToSqlOutput::from(s))
+    }
+}
+
+/// Dynamically initialized engine state.
+pub struct OnDemandState<T> {
+    #[expect(clippy::type_complexity)]
+    init: Rc<Cell<Option<Box<dyn FnOnce() -> T>>>>,
+    state: Rc<RefCell<Option<T>>>,
+}
+
+impl<T> OnDemandState<T> {
+    pub fn new(init: Box<dyn FnOnce() -> T>) -> Self {
+        Self { init: Rc::new(Cell::new(Some(init))), state: Default::default() }
+    }
+
+    /// Get the initialized engine state.
+    pub fn get(&self) -> RefMut<'_, T> {
+        if let Some(init) = self.init.take() {
+            *self.state.borrow_mut() = Some(init());
+        }
+
+        RefMut::map(self.state.borrow_mut(), |state| state.as_mut().unwrap())
+    }
+
+    /// Get the engine state, without initializing it if missing.
+    pub fn try_get(&self) -> RefMut<'_, Option<T>> {
+        self.state.borrow_mut()
+    }
+}
+
+impl<T> Clone for OnDemandState<T> {
+    fn clone(&self) -> Self {
+        Self { init: self.init.clone(), state: self.state.clone() }
+    }
 }

--- a/src/engine/servo.rs
+++ b/src/engine/servo.rs
@@ -1,0 +1,953 @@
+//! Servo browser engine.
+
+use std::any::Any;
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::ptr::NonNull;
+use std::rc::Rc;
+use std::sync::LazyLock;
+use std::{env, mem};
+
+use _text_input::zwp_text_input_v3::ContentPurpose;
+use euclid::Scale;
+use funq::MtQueueHandle;
+use keyboard_types::{Code, Key, KeyState, KeyboardEvent, Location, Modifiers as ServoModifiers};
+use raw_window_handle::{
+    DisplayHandle, RawDisplayHandle, RawWindowHandle, WaylandWindowHandle, WindowHandle,
+};
+use servo::{
+    ClipboardDelegate, CompositionEvent, CompositionState, ContextMenu as ServoContextMenu,
+    EmbedderControl, EmbedderControlId, EventLoopWaker, ImeEvent, InputEvent, InputMethodType,
+    LoadStatus, MouseButton, MouseButtonAction, MouseButtonEvent, MouseMoveEvent, Opts,
+    PixelFormat, Preferences, RenderingContext, Servo, ServoBuilder, StringRequest, TouchEvent,
+    TouchEventType, TouchId, WebView, WebViewBuilder, WebViewDelegate, WheelDelta, WheelEvent,
+    WheelMode, WindowRenderingContext,
+};
+use smithay_client_toolkit::reexports::client::Proxy;
+use smithay_client_toolkit::reexports::client::protocol::wl_surface::WlSurface;
+use smithay_client_toolkit::reexports::protocols::wp::text_input::zv3::client as _text_input;
+use smithay_client_toolkit::seat::keyboard::{Keysym, Modifiers};
+use smithay_client_toolkit::seat::pointer::AxisScroll;
+use tracing::{debug, error};
+use url::Url;
+use xkbcommon_dl::{XkbCommon, xkbcommon_handle};
+
+use crate::config::CONFIG;
+use crate::engine::{ContextMenu, Engine, EngineHandler, EngineId, EngineType, Favicon, FaviconId};
+use crate::storage::cookie_whitelist::CookieWhitelist;
+use crate::ui::overlay::option_menu::{Anchor, OptionMenuId, OptionMenuPosition};
+use crate::window::{self, PasteTarget, TextInputChange, TextInputState, WindowHandler, WindowId};
+use crate::{Position, Size, State, Window, gl};
+
+#[funq::callbacks(State)]
+trait ServoHandler {
+    /// Handle wakeup from Servo event loop.
+    fn wakeup(&mut self);
+
+    /// Handle frame ready events.
+    fn frame(&mut self, engine_id: EngineId);
+
+    /// Open popup.
+    fn open_menu(&mut self, engine_id: EngineId, menu: ServoContextMenu);
+
+    /// Close popup.
+    fn close_menu(&mut self, menu_id: OptionMenuId);
+
+    /// Handle Servo embedder control closure.
+    fn close_embedder_control(&mut self, engine_id: EngineId, id: EmbedderControlId);
+
+    /// Update IME state.
+    fn set_text_input_state(
+        &mut self,
+        engine_id: EngineId,
+        id: EmbedderControlId,
+        text_input_state: TextInputState,
+        full_text: String,
+    );
+
+    /// Handle animation state changes.
+    fn set_animating(&mut self, engine_id: EngineId, animating: bool);
+}
+
+impl ServoHandler for State {
+    fn wakeup(&mut self) {
+        self.servo_state.get().servo.spin_event_loop();
+    }
+
+    fn frame(&mut self, engine_id: EngineId) {
+        let window = match self.windows.get_mut(&engine_id.window_id()) {
+            Some(window) => window,
+            None => return,
+        };
+        let servo_engine = match servo_engine_by_id(window, engine_id) {
+            Some(servo_engine) => servo_engine,
+            None => return,
+        };
+
+        servo_engine.dirty = true;
+
+        // Wakeup renderer if this engine is active.
+        if window.active_tab().is_some_and(|tab| tab.id() == engine_id) {
+            window.unstall();
+        }
+    }
+
+    fn open_menu(&mut self, engine_id: EngineId, menu: ServoContextMenu) {
+        let window = match self.windows.get_mut(&engine_id.window_id()) {
+            Some(window) => window,
+            None => return,
+        };
+        let servo_engine = match servo_engine_by_id(window, engine_id) {
+            Some(servo_engine) => servo_engine,
+            None => return,
+        };
+
+        // Create generic context menu from Servo menu.
+        let engine_url = servo_engine.uri();
+        let menu_target = menu.element_info();
+        let target_flags = menu_target.flags.into();
+        let target_url = menu_target.link_url.as_ref().or(menu_target.image_url.as_ref());
+        let context_menu = ContextMenu::new(
+            #[cfg(feature = "webkit")]
+            EngineType::Servo,
+            target_flags,
+            &servo_engine.cookie_whitelist,
+            &engine_url,
+            target_url.map(|url| url.to_string()),
+        );
+        let items = context_menu.items();
+
+        // Get popup position.
+        let menu_rect = menu.position();
+        let menu_position = OptionMenuPosition::new(menu_rect.min.into(), Anchor::BottomRight);
+        let item_width = match menu_rect.max.x - menu_rect.min.x {
+            item_width @ 1.. => Some(item_width as u32),
+            _ => None,
+        };
+
+        // Update engine's active popup for close/activate handling.
+        let menu_id = OptionMenuId::with_engine(engine_id);
+        if let Some((menu_id, ..)) = &servo_engine.menu {
+            servo_engine.close_option_menu(Some(*menu_id));
+        }
+        servo_engine.menu = Some((menu_id, menu.id(), menu, context_menu));
+
+        // Show the popup.
+        window.open_option_menu(menu_id, menu_position, item_width, items.into_iter());
+    }
+
+    fn close_menu(&mut self, menu_id: OptionMenuId) {
+        let engine_id = match menu_id.engine_id() {
+            Some(engine_id) => engine_id,
+            None => return,
+        };
+        let window = match self.windows.get_mut(&menu_id.window_id()) {
+            Some(window) => window,
+            None => return,
+        };
+        let servo_engine = match servo_engine_by_id(window, engine_id) {
+            Some(servo_engine) => servo_engine,
+            None => return,
+        };
+
+        // Clear engine's option menu if it matches the menu's ID.
+        if servo_engine.menu.as_ref().is_some_and(|(id, ..)| menu_id == *id) {
+            servo_engine.menu = None;
+        }
+
+        window.close_option_menu(menu_id);
+    }
+
+    fn close_embedder_control(&mut self, engine_id: EngineId, id: EmbedderControlId) {
+        let window = match self.windows.get_mut(&engine_id.window_id()) {
+            Some(window) => window,
+            None => return,
+        };
+        let servo_engine = match servo_engine_by_id(window, engine_id) {
+            Some(servo_engine) => servo_engine,
+            None => return,
+        };
+
+        match (&servo_engine.menu, servo_engine.text_input_id) {
+            // Handle context menu dismissal.
+            (&Some((menu_id, embedder_id, ..)), _) if embedder_id == id => {
+                servo_engine.menu = None;
+                window.close_option_menu(menu_id);
+            },
+            // Handle IME dismissal.
+            (None, Some(embedder_id)) if embedder_id == id => {
+                servo_engine.text_input_id = None;
+                servo_engine.text_input_change = TextInputChange::Disabled;
+                window.unstall();
+            },
+            _ => (),
+        }
+    }
+
+    fn set_text_input_state(
+        &mut self,
+        engine_id: EngineId,
+        id: EmbedderControlId,
+        text_input_state: TextInputState,
+        full_text: String,
+    ) {
+        let window = match self.windows.get_mut(&engine_id.window_id()) {
+            Some(window) => window,
+            None => return,
+        };
+        let servo_engine = match servo_engine_by_id(window, engine_id) {
+            Some(servo_engine) => servo_engine,
+            None => return,
+        };
+
+        // Update current text field state.
+        servo_engine.text_input_cursor = text_input_state.cursor_index as u32;
+        servo_engine.text_input_text = full_text;
+
+        // Update IME state.
+        servo_engine.text_input_change = TextInputChange::Dirty(text_input_state);
+        servo_engine.text_input_id = Some(id);
+
+        window.unstall();
+    }
+
+    fn set_animating(&mut self, engine_id: EngineId, animating: bool) {
+        let window = match self.windows.get_mut(&engine_id.window_id()) {
+            Some(window) => window,
+            None => return,
+        };
+        let engine = match window.tab_mut(engine_id) {
+            Some(engine) => engine,
+            None => return,
+        };
+        let servo_engine = match engine.as_any().downcast_mut::<ServoEngine>() {
+            Some(servo_engine) => servo_engine,
+            None => return,
+        };
+
+        servo_engine.animating = animating;
+        window.unstall();
+    }
+}
+
+/// Global Servo engine state.
+pub struct ServoState {
+    rendering_contexts: HashMap<WindowId, Rc<dyn RenderingContext>>,
+    cookie_whitelist: CookieWhitelist,
+    queue: MtQueueHandle<State>,
+    display: RawDisplayHandle,
+    servo: Rc<Servo>,
+}
+
+impl ServoState {
+    #[cfg_attr(feature = "profiling", profiling::function)]
+    pub fn new(
+        display: RawDisplayHandle,
+        queue: MtQueueHandle<State>,
+        cookie_whitelist: CookieWhitelist,
+    ) -> Self {
+        let config = CONFIG.read().unwrap();
+        let [bg_r, bg_g, bg_b] = config.colors.background.as_f64();
+        let monospace_font = config.font.monospace_family.to_string();
+        let font = config.font.family.to_string();
+        let font_size = config.font.size.round() as i64;
+
+        // Initialize Servo engine.
+        let waker = Box::new(Waker::new(queue.clone()));
+        let servo = Rc::new(
+            ServoBuilder::default()
+                .preferences(Preferences {
+                    shell_background_color_rgba: [bg_r, bg_g, bg_b, 1.],
+                    fonts_default_monospace_size: font_size,
+                    fonts_default_size: font_size,
+                    fonts_monospace: monospace_font,
+                    fonts_sans_serif: font.clone(),
+                    fonts_default: font.clone(),
+                    fonts_serif: font,
+                    ..Default::default()
+                })
+                .opts(Opts { hard_fail: false, ..Default::default() })
+                .event_loop_waker(waker)
+                .build(),
+        );
+
+        Self { cookie_whitelist, display, queue, servo, rendering_contexts: Default::default() }
+    }
+
+    /// Create a new Servo engine from this state.
+    pub fn create_engine(
+        &mut self,
+        surface: &WlSurface,
+        id: EngineId,
+        size: Size,
+        scale: f64,
+        url: Option<&str>,
+    ) -> Result<ServoEngine, surfman::error::Error> {
+        // Create a new rendering context for this web view.
+        let size = size * scale;
+        let entry = self.rendering_contexts.entry(id.window_id());
+        let renderer = match entry {
+            Entry::Occupied(occupied) => occupied.into_mut(),
+            Entry::Vacant(vacant) => {
+                // Get handles to Wayland window and display.
+                let surface_ptr = NonNull::new(surface.id().as_ptr().cast()).unwrap();
+                let wayland_window = WaylandWindowHandle::new(surface_ptr);
+                let raw_window = RawWindowHandle::Wayland(wayland_window);
+                let window = unsafe { WindowHandle::borrow_raw(raw_window) };
+                let display = unsafe { DisplayHandle::borrow_raw(self.display) };
+
+                let size = size.into();
+                let context = match WindowRenderingContext::new(display, window, size) {
+                    Ok(context) => context,
+                    // Retry with GLES to support older hardware.
+                    Err(_) => {
+                        unsafe { env::set_var("SURFMAN_FORCE_GLES", "1") };
+                        WindowRenderingContext::new(display, window, size)?
+                    },
+                };
+
+                vacant.insert(Rc::new(context))
+            },
+        };
+
+        // Create this engine's servo web view.
+        let url = url
+            .and_then(|url| Url::parse(url).ok())
+            .unwrap_or_else(|| Url::parse("about:blank").unwrap());
+        let web_view_handler = Rc::new(WebViewHandler::new(self.queue.clone(), id));
+        let web_view = WebViewBuilder::new(&self.servo, renderer.clone())
+            .hidpi_scale_factor(Scale::new(scale as f32))
+            .clipboard_delegate(web_view_handler.clone())
+            .delegate(web_view_handler)
+            .url(url)
+            .build();
+
+        Ok(ServoEngine {
+            web_view,
+            scale,
+            size,
+            id,
+            cookie_whitelist: self.cookie_whitelist.clone(),
+            text_input_change: TextInputChange::Disabled,
+            renderer: renderer.clone(),
+            servo: self.servo.clone(),
+            queue: self.queue.clone(),
+            dirty: true,
+            text_input_cursor: Default::default(),
+            text_input_text: Default::default(),
+            pending_resize: Default::default(),
+            text_input_id: Default::default(),
+            animating: Default::default(),
+            menu: Default::default(),
+        })
+    }
+
+    /// Handle window destruction.
+    pub fn on_window_close(&mut self, window_id: WindowId) {
+        self.rendering_contexts.retain(|id, _| *id != window_id);
+    }
+}
+
+/// Servo browser engine.
+pub struct ServoEngine {
+    renderer: Rc<dyn RenderingContext>,
+    web_view: WebView,
+    servo: Rc<Servo>,
+
+    menu: Option<(OptionMenuId, EmbedderControlId, ServoContextMenu, ContextMenu)>,
+    cookie_whitelist: CookieWhitelist,
+
+    pending_resize: Option<Size>,
+    size: Size,
+    scale: f64,
+
+    queue: MtQueueHandle<State>,
+    id: EngineId,
+
+    text_input_id: Option<EmbedderControlId>,
+    text_input_change: TextInputChange,
+    text_input_text: String,
+    text_input_cursor: u32,
+
+    animating: bool,
+    dirty: bool,
+}
+
+impl Engine for ServoEngine {
+    fn id(&self) -> EngineId {
+        self.id
+    }
+
+    fn engine_type(&self) -> EngineType {
+        EngineType::Servo
+    }
+
+    fn dirty(&mut self) -> bool {
+        self.dirty || self.animating
+    }
+
+    fn set_visible(&mut self, visible: bool) {
+        if visible {
+            self.web_view.show();
+        } else {
+            self.web_view.hide();
+        }
+    }
+
+    #[cfg_attr(feature = "profiling", profiling::function)]
+    fn draw(&mut self) -> bool {
+        self.dirty = false;
+
+        // Update Wayland surface dimensions.
+        self.size = self.renderer.size().into();
+
+        // Process all pending Servo events.
+        self.servo.spin_event_loop();
+
+        // If a size change is pending, resize the webview and trigger a redraw.
+        //
+        // While this should be done before rendering to avoid drawing twice, Servo
+        // frequently calls `make_current` causing the surface size to latch to
+        // arbitrary sizes. By resizing right after rendering, we are able to  ensure
+        // the requested size will be accurate for the next redraw.
+        if let Some(pending_resize) = self.pending_resize.take() {
+            let size = pending_resize * self.scale;
+            self.web_view.resize(size.into());
+            self.dirty = true;
+        }
+
+        self.web_view.paint();
+        self.renderer.present();
+
+        true
+    }
+
+    fn buffer_size(&self) -> Size {
+        self.size
+    }
+
+    fn set_size(&mut self, size: Size) {
+        self.pending_resize = Some(size);
+
+        // Mark engine as ready for redraw.
+        // Unstall is called automatically in window.rs on resize.
+        self.dirty = true;
+    }
+
+    fn set_scale(&mut self, scale: f64) {
+        if scale == self.scale {
+            return;
+        }
+        self.scale = scale;
+
+        // Ensure engine is resized to its new dimensions.
+        if self.pending_resize.is_none() {
+            self.pending_resize = Some(self.size);
+        }
+
+        // Update the engine's render scale.
+        self.web_view.set_hidpi_scale_factor(Scale::new(scale as f32));
+
+        // Mark engine as ready for redraw.
+        // Unstall is called automatically in window.rs on scale change.
+        self.dirty = true;
+    }
+
+    fn press_key(&mut self, _time: u32, raw: u32, keysym: Keysym, modifiers: Modifiers) {
+        let (key, code) = match (keysym_to_key(keysym), Code::from_xkb_kecode(raw)) {
+            (Some(key), Some(code)) => (key, code),
+            _ => return,
+        };
+        let location = Location::from_xkb_keysym(keysym.raw());
+        let modifiers = servo_modifiers(modifiers);
+
+        let event = KeyboardEvent {
+            modifiers,
+            location,
+            code,
+            key,
+            state: KeyState::Down,
+            is_composing: Default::default(),
+            repeat: Default::default(),
+        };
+        self.web_view.notify_input_event(InputEvent::Keyboard(servo::KeyboardEvent::new(event)));
+    }
+
+    fn release_key(&mut self, _time: u32, raw: u32, keysym: Keysym, modifiers: Modifiers) {
+        let (key, code) = match (keysym_to_key(keysym), Code::from_xkb_kecode(raw)) {
+            (Some(key), Some(code)) => (key, code),
+            _ => return,
+        };
+        let location = Location::from_xkb_keysym(keysym.raw());
+        let modifiers = servo_modifiers(modifiers);
+
+        let event = KeyboardEvent {
+            modifiers,
+            location,
+            code,
+            key,
+            state: KeyState::Up,
+            is_composing: Default::default(),
+            repeat: Default::default(),
+        };
+        self.web_view.notify_input_event(InputEvent::Keyboard(servo::KeyboardEvent::new(event)));
+    }
+
+    fn pointer_axis(
+        &mut self,
+        _time: u32,
+        position: Position<f64>,
+        horizontal: AxisScroll,
+        vertical: AxisScroll,
+        _modifiers: Modifiers,
+    ) {
+        let position = position * self.scale;
+        let delta = WheelDelta {
+            x: horizontal.absolute,
+            y: -vertical.absolute,
+            z: 0.,
+            mode: WheelMode::DeltaPixel,
+        };
+        let event = WheelEvent::new(delta, position.into());
+        self.web_view.notify_input_event(InputEvent::Wheel(event));
+    }
+
+    fn pointer_button(
+        &mut self,
+        _time: u32,
+        position: Position<f64>,
+        button: u32,
+        down: bool,
+        _modifiers: Modifiers,
+    ) {
+        self.web_view.focus();
+
+        let position = position * self.scale;
+        let button = match button {
+            272 => MouseButton::Left,
+            273 => MouseButton::Right,
+            274 => MouseButton::Middle,
+            // Auxiliary mouse buttons are not supported by Servo.
+            _ => return,
+        };
+        let action = if down { MouseButtonAction::Down } else { MouseButtonAction::Up };
+        let event = MouseButtonEvent::new(action, button, position.into());
+
+        self.web_view.notify_input_event(InputEvent::MouseButton(event));
+    }
+
+    fn pointer_motion(&mut self, _time: u32, position: Position<f64>, _modifiers: Modifiers) {
+        let position = position * self.scale;
+        let event = MouseMoveEvent::new(position.into());
+        self.web_view.notify_input_event(InputEvent::MouseMove(event));
+    }
+
+    fn touch_down(&mut self, _time: u32, id: i32, position: Position<f64>, _modifiers: Modifiers) {
+        self.web_view.focus();
+
+        let position = position * self.scale;
+        let event = TouchEvent::new(TouchEventType::Down, TouchId(id), position.into());
+        self.web_view.notify_input_event(InputEvent::Touch(event));
+    }
+
+    fn touch_up(&mut self, _time: u32, id: i32, position: Position<f64>, _modifiers: Modifiers) {
+        let position = position * self.scale;
+        let event = TouchEvent::new(TouchEventType::Up, TouchId(id), position.into());
+        self.web_view.notify_input_event(InputEvent::Touch(event));
+    }
+
+    fn touch_motion(
+        &mut self,
+        _time: u32,
+        id: i32,
+        position: Position<f64>,
+        _modifiers: Modifiers,
+    ) {
+        let position = position * self.scale;
+        let event = TouchEvent::new(TouchEventType::Move, TouchId(id), position.into());
+        self.web_view.notify_input_event(InputEvent::Touch(event));
+    }
+
+    fn reload(&mut self) {
+        self.web_view.reload();
+    }
+
+    fn load_uri(&mut self, url: &str) {
+        match Url::parse(url) {
+            Ok(url) => self.web_view.load(url),
+            Err(err) => error!("Invalid URL {url:?}: {err}"),
+        }
+    }
+
+    fn load_prev(&mut self) {
+        self.web_view.go_back(1);
+    }
+
+    fn has_prev(&self) -> bool {
+        self.web_view.can_go_back()
+    }
+
+    fn uri(&self) -> Cow<'_, str> {
+        self.web_view.url().map_or(Cow::Borrowed(""), |url| url.to_string().into())
+    }
+
+    fn title(&self) -> Cow<'_, str> {
+        self.web_view.page_title().map_or(Cow::Borrowed(""), |title| title.into())
+    }
+
+    fn text_input_state(&mut self) -> TextInputChange {
+        mem::replace(&mut self.text_input_change, TextInputChange::Unchanged)
+    }
+
+    fn delete_surrounding_text(&mut self, before_length: u32, after_length: u32) {
+        let start = self.text_input_cursor.saturating_sub(before_length) as usize;
+        let end = (self.text_input_cursor + after_length) as usize;
+
+        // Remove deleted text section.
+        let mut text = self.text_input_text.clone();
+        text.drain(start..end.min(text.len()));
+
+        let event =
+            ImeEvent::Composition(CompositionEvent { state: CompositionState::Update, data: text });
+        self.web_view.notify_input_event(InputEvent::Ime(event));
+    }
+
+    fn commit_string(&mut self, text: String) {
+        let event =
+            ImeEvent::Composition(CompositionEvent { state: CompositionState::End, data: text });
+        self.web_view.notify_input_event(InputEvent::Ime(event));
+    }
+
+    fn set_preedit_string(&mut self, text: String, _cursor_begin: i32, _cursor_end: i32) {
+        let event =
+            ImeEvent::Composition(CompositionEvent { state: CompositionState::Update, data: text });
+        self.web_view.notify_input_event(InputEvent::Ime(event));
+    }
+
+    fn clear_focus(&mut self) {
+        self.web_view.blur();
+    }
+
+    fn submit_option_menu(&mut self, menu_id: OptionMenuId, index: usize) {
+        if self.menu.as_ref().is_none_or(|(id, ..)| *id != menu_id) {
+            return;
+        }
+        let (id, _, _, menu) = self.menu.take().unwrap();
+
+        // Activate selected option.
+        menu.activate_item(self.queue.clone(), self.id, index as u32);
+
+        // Close Kumo's option menu UI.
+        self.queue.close_menu(id);
+    }
+
+    fn close_option_menu(&mut self, menu_id: Option<OptionMenuId>) {
+        if menu_id.is_some_and(|menu_id| Some(&menu_id) != self.menu.as_ref().map(|(id, ..)| id))
+            || self.menu.is_none()
+        {
+            return;
+        }
+        let (id, _, servo_menu, _) = self.menu.take().unwrap();
+
+        // Notify menu about being closed from our end.
+        servo_menu.dismiss();
+
+        // Close Kumo's option menu UI.
+        self.queue.close_menu(id);
+    }
+
+    fn set_fullscreen(&mut self, fullscreen: bool) {
+        if !fullscreen {
+            self.web_view.exit_fullscreen();
+        }
+    }
+
+    #[cfg_attr(feature = "profiling", profiling::function)]
+    fn favicon(&self) -> Option<Favicon> {
+        let favicon = self.web_view.favicon()?;
+
+        let format = match favicon.format {
+            PixelFormat::K8 | PixelFormat::KA8 => {
+                debug!("Unsupported Servo favicon format");
+                return None;
+            },
+            PixelFormat::RGB8 => gl::RGB,
+            PixelFormat::RGBA8 => gl::RGBA,
+            PixelFormat::BGRA8 => gl::BGRA_EXT,
+        };
+
+        (favicon.width > 0 && favicon.height > 0).then_some(Favicon {
+            format,
+            bytes: glib::Bytes::from(favicon.data()),
+            id: FaviconId::new_servo(),
+            width: favicon.width as usize,
+            height: favicon.height as usize,
+        })
+    }
+
+    fn set_zoom_level(&mut self, zoom_level: f64) {
+        // Zoom towards the center of the webview.
+        let x = self.size.width as f32 * 0.5;
+        let y = self.size.height as f32 * 0.5;
+        let center = Position::new(x, y);
+
+        // Calculate factor based on current zoom level.
+        let delta = zoom_level / self.web_view.pinch_zoom() as f64;
+
+        // Update zoom level.
+        self.web_view.adjust_pinch_zoom(delta as f32, center.into());
+
+        // Dispatch events to trigger a redraw.
+        self.servo.spin_event_loop();
+    }
+
+    fn zoom_level(&self) -> f64 {
+        self.web_view.pinch_zoom() as f64
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// Servo event loop waker.
+#[derive(Clone)]
+struct Waker {
+    queue: MtQueueHandle<State>,
+}
+
+impl Waker {
+    fn new(queue: MtQueueHandle<State>) -> Self {
+        Self { queue }
+    }
+}
+
+impl EventLoopWaker for Waker {
+    fn clone_box(&self) -> Box<dyn EventLoopWaker> {
+        Box::new(self.clone())
+    }
+
+    fn wake(&self) {
+        self.queue.clone().wakeup();
+    }
+}
+
+/// Servo web view event handler.
+#[derive(Clone)]
+struct WebViewHandler {
+    queue: MtQueueHandle<State>,
+    engine_id: EngineId,
+}
+
+impl WebViewHandler {
+    fn new(queue: MtQueueHandle<State>, engine_id: EngineId) -> Self {
+        Self { engine_id, queue }
+    }
+}
+
+impl WebViewDelegate for WebViewHandler {
+    fn notify_new_frame_ready(&self, _web_view: WebView) {
+        self.queue.clone().frame(self.engine_id);
+    }
+
+    fn notify_url_changed(&self, _webview: WebView, url: Url) {
+        self.queue.clone().set_engine_uri(self.engine_id, url.to_string(), true);
+    }
+
+    fn notify_page_title_changed(&self, _webview: WebView, title: Option<String>) {
+        self.queue.clone().set_engine_title(self.engine_id, title.unwrap_or_default());
+    }
+
+    fn notify_animating_changed(&self, _webview: WebView, animating: bool) {
+        self.queue.clone().set_animating(self.engine_id, animating);
+    }
+
+    fn notify_load_status_changed(&self, _webview: WebView, status: LoadStatus) {
+        match status {
+            LoadStatus::Started => self.queue.clone().set_load_progress(self.engine_id, 0.),
+            LoadStatus::HeadParsed => self.queue.clone().set_load_progress(self.engine_id, 0.5),
+            LoadStatus::Complete => self.queue.clone().set_load_progress(self.engine_id, 1.),
+        }
+    }
+
+    fn notify_favicon_changed(&self, _webview: WebView) {
+        self.queue.clone().update_favicon(self.engine_id);
+    }
+
+    fn notify_crashed(&self, _webview: WebView, reason: String, backtrace: Option<String>) {
+        error!("Servo WebView crashed: {reason}");
+
+        // Print full backtrace when `RUST_BACKTRACE=1` is set.
+        if let Some(backtrace) = backtrace
+            && env::var("RUST_BACKTRACE").as_deref() == Ok("1")
+        {
+            error!("Servo backtrace:\n{backtrace}");
+        }
+    }
+
+    fn notify_fullscreen_state_changed(&self, _webview: WebView, fullscreen: bool) {
+        self.queue.clone().set_fullscreen(self.engine_id, fullscreen);
+    }
+
+    fn show_embedder_control(&self, _webview: WebView, embedder_control: EmbedderControl) {
+        let embedder_id = embedder_control.id();
+
+        match embedder_control {
+            EmbedderControl::InputMethod(ime) => {
+                // Calculate input field dimensions.
+                let position = ime.position();
+                let width = position.max.x - position.min.x;
+                let height = position.max.y - position.min.y;
+                let cursor_rect = (position.min.x, position.min.y, width, height);
+
+                // Convert Servo to Wayland input purpose.
+                let purpose = match ime.input_method_type() {
+                    InputMethodType::Date => ContentPurpose::Date,
+                    InputMethodType::DatetimeLocal => ContentPurpose::Datetime,
+                    InputMethodType::Email => ContentPurpose::Email,
+                    InputMethodType::Number => ContentPurpose::Number,
+                    InputMethodType::Password => ContentPurpose::Password,
+                    InputMethodType::Tel => ContentPurpose::Phone,
+                    InputMethodType::Time => ContentPurpose::Time,
+                    InputMethodType::Url => ContentPurpose::Url,
+                    InputMethodType::Color
+                    | InputMethodType::Month
+                    | InputMethodType::Search
+                    | InputMethodType::Text
+                    | InputMethodType::Week => ContentPurpose::Normal,
+                };
+
+                // Clamp IME text to protocol limits.
+                let full_text = ime.text();
+                let cursor_index = ime.insertion_point().unwrap_or(0);
+                let (surrounding_text, cursor_index, _) = window::clamp_surrounding_text(
+                    &full_text,
+                    cursor_index as usize,
+                    cursor_index as usize,
+                    window::MAX_SURROUNDING_BYTES,
+                );
+
+                let state = TextInputState {
+                    surrounding_text,
+                    cursor_index,
+                    cursor_rect,
+                    purpose,
+                    ..Default::default()
+                };
+
+                self.queue.clone().set_text_input_state(
+                    self.engine_id,
+                    embedder_id,
+                    state,
+                    full_text,
+                );
+            },
+            EmbedderControl::ContextMenu(menu) => {
+                self.queue.clone().open_menu(self.engine_id, menu);
+            },
+            EmbedderControl::ColorPicker(_)
+            | EmbedderControl::FilePicker(_)
+            | EmbedderControl::SelectElement(_)
+            | EmbedderControl::SimpleDialog(_) => {
+                debug!("Servo requested unsupported embedder controls")
+            },
+        }
+    }
+
+    fn hide_embedder_control(&self, _webview: WebView, embedder_id: EmbedderControlId) {
+        self.queue.clone().close_embedder_control(self.engine_id, embedder_id);
+    }
+}
+
+impl ClipboardDelegate for WebViewHandler {
+    fn get_text(&self, _webview: WebView, request: StringRequest) {
+        self.queue.clone().request_paste(PasteTarget::Servo(self.engine_id, request));
+    }
+
+    fn set_text(&self, _webview: WebView, text: String) {
+        self.queue.clone().set_clipboard(text);
+    }
+
+    fn clear(&self, _webview: WebView) {
+        self.queue.clone().set_clipboard(String::new());
+    }
+}
+
+/// Get and downcast a Servo engine from a window.
+fn servo_engine_by_id(window: &mut Window, engine_id: EngineId) -> Option<&mut ServoEngine> {
+    let engine = window.tab_mut(engine_id)?;
+    engine.as_any().downcast_mut::<ServoEngine>()
+}
+
+/// Convert Wayland to Servo modifiers.
+fn servo_modifiers(modifiers: Modifiers) -> ServoModifiers {
+    let mut servo_modifiers = ServoModifiers::empty();
+    servo_modifiers.set(ServoModifiers::CAPS_LOCK, modifiers.caps_lock);
+    servo_modifiers.set(ServoModifiers::NUM_LOCK, modifiers.num_lock);
+    servo_modifiers.set(ServoModifiers::CONTROL, modifiers.ctrl);
+    servo_modifiers.set(ServoModifiers::SHIFT, modifiers.shift);
+    servo_modifiers.set(ServoModifiers::META, modifiers.logo);
+    servo_modifiers.set(ServoModifiers::ALT, modifiers.alt);
+    servo_modifiers
+}
+
+/// Convert a Wayland [`Keysym`] to a Servo [`Key`].
+fn keysym_to_key(keysym: Keysym) -> Option<Key> {
+    let raw_keysym = keysym.raw();
+    if raw_keysym == 0 {
+        return None;
+    }
+
+    Key::from_xkb_keysym(raw_keysym).or_else(|| {
+        let mut buffer = [0; 8];
+        let key_utf8 = raw_keysym_to_utf8(&mut buffer, raw_keysym)?;
+        Some(Key::Character(key_utf8.into()))
+    })
+}
+
+/// Try to convert a raw keysym to a UTF8 string.
+fn raw_keysym_to_utf8(buffer: &mut [u8], keysym: u32) -> Option<&str> {
+    static XKBH: LazyLock<&'static XkbCommon> = LazyLock::new(xkbcommon_handle);
+
+    let bytes_written =
+        unsafe { (XKBH.xkb_keysym_to_utf8)(keysym, buffer.as_mut_ptr().cast(), buffer.len()) };
+
+    match bytes_written {
+        ..0 => {
+            error!("Insufficient space to convert keysym {keysym}");
+            None
+        },
+        0 | 1 => None,
+        bytes_written => str::from_utf8(&buffer[..bytes_written as usize - 1])
+            .inspect_err(|err| error!("Failed to parse bytes for keysym {keysym} as UTF-8: {err}"))
+            .ok(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use keyboard_types::NamedKey;
+    use xkbcommon_dl::keysyms;
+
+    use super::*;
+
+    #[test]
+    fn raw_to_utf8() {
+        let mut buffer = [0; 8];
+
+        assert_eq!(raw_keysym_to_utf8(&mut buffer, keysyms::Aacute), Some("Á"));
+        assert_eq!(raw_keysym_to_utf8(&mut buffer, keysyms::T), Some("T"));
+
+        assert_eq!(raw_keysym_to_utf8(&mut buffer, keysyms::NoSymbol), None);
+        assert_eq!(raw_keysym_to_utf8(&mut buffer, 0), None);
+    }
+
+    #[test]
+    fn sym_to_key() {
+        assert_eq!(keysym_to_key(Keysym::Escape), Some(Key::Named(NamedKey::Escape)));
+        assert_eq!(keysym_to_key(Keysym::T), Some(Key::Character("T".into())));
+
+        assert_eq!(keysym_to_key(Keysym::NoSymbol), None);
+    }
+}

--- a/src/engine/webkit/input_method_context.rs
+++ b/src/engine/webkit/input_method_context.rs
@@ -1,17 +1,9 @@
 //! IME subclass implementation.
 
-use std::mem;
-
 use glib::Object;
 use glib::subclass::types::ObjectSubclassIsExt;
 
 use crate::window::TextInputChange;
-
-/// Maximum number of surrounding bytes submitted to IME.
-///
-/// The value `4000` is chosen to match the maximum Wayland protocol message
-/// size, a higher value will lead to errors.
-const MAX_SURROUNDING_BYTES: usize = 4000;
 
 mod imp {
     use std::cell::Cell;
@@ -25,7 +17,7 @@ mod imp {
         InputHints, InputMethodContextExt, InputMethodContextImpl, InputPurpose, PreeditString,
     };
 
-    use crate::window::{TextInputChange, TextInputState};
+    use crate::window::{self, TextInputChange, TextInputState};
 
     #[derive(Default)]
     pub struct InputMethodContext {
@@ -115,11 +107,11 @@ mod imp {
 
         fn set_surrounding(&self, text: &str, cursor_index: u32, selection_index: u32) {
             if let Some(mut text_input_state) = self.text_input_state.take() {
-                let (text, start, end) = super::clamp_surrounding_text(
+                let (text, start, end) = window::clamp_surrounding_text(
                     text,
                     cursor_index as usize,
                     selection_index as usize,
-                    super::MAX_SURROUNDING_BYTES,
+                    window::MAX_SURROUNDING_BYTES,
                 );
 
                 text_input_state.surrounding_text = text;
@@ -189,79 +181,5 @@ impl InputMethodContext {
 impl Default for InputMethodContext {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-/// Clamp surrounding text to at most `max_len`.
-pub fn clamp_surrounding_text(
-    text: &str,
-    mut cursor_start: usize,
-    mut cursor_end: usize,
-    max_bytes: usize,
-) -> (String, i32, i32) {
-    // Ensure start/end are in the right order.
-    if cursor_start > cursor_end {
-        mem::swap(&mut cursor_start, &mut cursor_end);
-    }
-
-    // If the cursor range is longer than the maximum allowed bytes, we ignore the
-    // start and just return the bytes surrounding the end.
-    let original_cursor_start = cursor_start as i32;
-    if cursor_end - cursor_start > max_bytes {
-        cursor_start = cursor_end;
-    }
-
-    // Calculate available bytes outside the cursor range.
-    let max_bytes = max_bytes - (cursor_end - cursor_start);
-
-    // Get up to half of the available bytes after the cursor end.
-    let mut end = cursor_end + max_bytes / 2;
-    if end >= text.len() {
-        end = text.len();
-    } else {
-        while end > 0 && !text.is_char_boundary(end) {
-            end -= 1;
-        }
-    };
-
-    // Get as many bytes as available before the cursor.
-    let remaining = max_bytes - (end - cursor_end);
-    let mut start = cursor_start.saturating_sub(remaining);
-    while start < text.len() && !text.is_char_boundary(start) {
-        start += 1;
-    }
-
-    // Calculate cursor indices relative to surrounding text.
-    let relative_start = original_cursor_start - start as i32;
-    let relative_end = cursor_end as i32 - start as i32;
-
-    (text[start..end].into(), relative_start, relative_end)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn surrounding_text() {
-        let (text, start, end) = clamp_surrounding_text("01234", 1, 4, 1);
-        assert_eq!(text, "3");
-        assert_eq!(start, -2);
-        assert_eq!(end, 1);
-
-        let (text, start, end) = clamp_surrounding_text("01234", 1, 4, 3);
-        assert_eq!(text, "123");
-        assert_eq!(start, 0);
-        assert_eq!(end, 3);
-
-        let (text, start, end) = clamp_surrounding_text("01234", 1, 4, 4);
-        assert_eq!(text, "0123");
-        assert_eq!(start, 1);
-        assert_eq!(end, 4);
-
-        let (text, start, end) = clamp_surrounding_text("01234", 1, 4, 99);
-        assert_eq!(text, "01234");
-        assert_eq!(start, 1);
-        assert_eq!(end, 4);
     }
 }

--- a/src/engine/webkit/mod.rs
+++ b/src/engine/webkit/mod.rs
@@ -15,8 +15,7 @@ use funq::StQueueHandle;
 use gio::Cancellable;
 use glib::object::{Cast, ObjectExt};
 use glib::prelude::*;
-use glib::{Bytes, GString, TimeSpan, Uri, UriFlags, UserDirectory};
-use glutin::display::Display;
+use glib::{Bytes, GString, TimeSpan, UserDirectory};
 use smithay_client_toolkit::compositor::Region;
 use smithay_client_toolkit::dmabuf::{DmabufFeedback, DmabufState};
 use smithay_client_toolkit::reexports::client::protocol::wl_buffer::WlBuffer;
@@ -34,19 +33,20 @@ use wpe_platform::{
 };
 use wpe_webkit::{
     Color, CookieAcceptPolicy, CookiePersistentStorage, Download as WebKitDownload, FindOptions,
-    HitTestResult, HitTestResultContext, LoadEvent, NetworkSession, OptionMenu,
-    OptionMenuItem as WebKitOptionMenuItem, UserContentFilterStore, WebView, WebViewExt,
-    WebViewSessionState, WebsiteDataManagerExtManual, WebsiteDataTypes,
+    HitTestResultContext, LoadEvent, NetworkSession, OptionMenu, UserContentFilterStore, WebView,
+    WebViewExt, WebViewSessionState, WebsiteDataManagerExtManual, WebsiteDataTypes,
 };
 
 use crate::config::CONFIG;
 use crate::engine::webkit::platform::WebKitDisplay;
-use crate::engine::{Engine, EngineHandler, EngineId, Favicon, GroupId};
+use crate::engine::{
+    ContextMenu, Engine, EngineHandler, EngineId, EngineType, Favicon, FaviconId, GroupId,
+};
 use crate::storage::cookie_whitelist::CookieWhitelist;
 use crate::ui::overlay::downloads::{Download, DownloadId};
 use crate::ui::overlay::option_menu::{Anchor, OptionMenuId, OptionMenuItem, OptionMenuPosition};
-use crate::window::{TextInputChange, Window, WindowHandler};
-use crate::{PasteTarget, Position, Size, State};
+use crate::window::{TextInputChange, Window};
+use crate::{Position, Size, State, gl};
 
 mod input_method_context;
 mod platform;
@@ -188,21 +188,6 @@ impl WebKitHandler for State {
             None => return,
         };
 
-        // Get properties from WebKit menu items.
-        let mut items = Vec::new();
-        for i in 0..menu.n_items() {
-            if let Some(mut item) = menu.item(i)
-                && let Some(label) = item.label()
-            {
-                items.push(OptionMenuItem {
-                    label: label.into(),
-                    description: String::new(),
-                    disabled: !item.is_enabled(),
-                    selected: item.is_selected(),
-                });
-            }
-        }
-
         // Get popup position.
         let (menu_position, item_width) = match rect {
             Some((x, y, width, height)) => {
@@ -215,14 +200,16 @@ impl WebKitHandler for State {
             },
         };
 
+        let items = menu.items();
+
         // Hookup close callback.
         let menu_id = OptionMenuId::with_engine(engine_id);
         let close_queue = self.queue.clone();
         menu.connect_close(move || close_queue.clone().close_menu(menu_id));
 
         // Update engine's active popup for close/activate handling.
-        if let Some((menu_id, _)) = webkit_engine.menu.take() {
-            webkit_engine.close_option_menu(Some(menu_id));
+        if let Some((menu_id, _)) = &webkit_engine.menu {
+            webkit_engine.close_option_menu(Some(*menu_id));
         }
         webkit_engine.menu = Some((menu_id, menu));
 
@@ -349,13 +336,13 @@ pub struct WebKitState {
     network_sessions: HashMap<GroupId, NetworkSession>,
     cookie_whitelist: CookieWhitelist,
     queue: StQueueHandle<State>,
-    display: Display,
+    drm_node: PathBuf,
 }
 
 impl WebKitState {
     #[cfg_attr(feature = "profiling", profiling::function)]
     pub fn new(
-        display: Display,
+        drm_node: PathBuf,
         queue: StQueueHandle<State>,
         cookie_whitelist: CookieWhitelist,
         all_groups: &HashSet<Uuid>,
@@ -386,7 +373,7 @@ impl WebKitState {
 
         Self {
             cookie_whitelist,
-            display,
+            drm_node,
             queue,
             network_sessions: Default::default(),
             dmabuf_feedback: Default::default(),
@@ -394,7 +381,14 @@ impl WebKitState {
     }
 
     /// Create a new WebKit engine from this state.
-    pub fn create_engine(&mut self, engine_id: EngineId, size: Size, scale: f64) -> WebKitEngine {
+    pub fn create_engine(
+        &mut self,
+        surface: WlSurface,
+        engine_id: EngineId,
+        size: Size,
+        scale: f64,
+        uri: Option<&str>,
+    ) -> WebKitEngine {
         // Create a new network session for this group if necessary.
         let group_id = engine_id.group_id();
         let network_session = self.network_sessions.entry(group_id).or_insert_with(|| {
@@ -405,16 +399,11 @@ impl WebKitState {
             network_session
         });
 
-        // Get the DRM render node.
-        let Display::Egl(egl_display) = &self.display;
-        let device = egl_display.device().expect("get DRM device");
-        let device_node = device.drm_device_node_path().expect("DRM node has no path");
-
         // Create WebKit platform.
         let webkit_display = WebKitDisplay::new(
             self.queue.clone(),
             engine_id,
-            device_node,
+            &self.drm_node,
             size,
             scale,
             self.dmabuf_feedback.borrow().as_ref(),
@@ -477,7 +466,25 @@ impl WebKitState {
         let context_menu_queue = self.queue.clone();
         web_view.connect_context_menu(move |web_view, _, hit_test_result| {
             let uri = web_view.uri().unwrap_or_default().to_string();
-            let context_menu = ContextMenu::new(&cookie_whitelist, &uri, hit_test_result.clone());
+            let context = HitTestResultContext::from_bits(hit_test_result.context())
+                .unwrap_or(HitTestResultContext::empty());
+            let target_uri = if context.contains(HitTestResultContext::LINK) {
+                hit_test_result.link_uri().map(String::from)
+            } else if context.contains(HitTestResultContext::IMAGE) {
+                hit_test_result.image_uri().map(String::from)
+            } else if context.contains(HitTestResultContext::MEDIA) {
+                hit_test_result.media_uri().map(String::from)
+            } else {
+                None
+            };
+
+            let context_menu = ContextMenu::new(
+                EngineType::WebKit,
+                context.into(),
+                &cookie_whitelist,
+                &uri,
+                target_uri,
+            );
             let menu = Menu::ContextMenu(context_menu);
             context_menu_queue.clone().open_menu(engine_id, menu, None);
             true
@@ -517,6 +524,11 @@ impl WebKitState {
         // Load adblock content filter.
         load_adblock(web_view.clone());
 
+        // Load the initial URI.
+        if let Some(uri) = uri {
+            web_view.load_uri(uri);
+        }
+
         WebKitEngine {
             webkit_display,
             web_view,
@@ -524,6 +536,7 @@ impl WebKitState {
             bg,
             dark_mode: config.colors.dark_mode,
             queue: self.queue.clone(),
+            surface,
             id: engine_id,
             buffers_pending_release: Default::default(),
             last_input_position: Default::default(),
@@ -551,6 +564,7 @@ pub struct WebKitEngine {
     buffer: Option<(WaylandBuffer, BufferDMABuf)>,
     buffer_damage: Option<Vec<WPERectangle>>,
     buffers_pending_release: [Option<(WaylandBuffer, BufferDMABuf)>; MAX_PENDING_BUFFERS],
+    surface: WlSurface,
 
     buffer_size: Size,
     scale: f64,
@@ -652,11 +666,16 @@ impl Engine for WebKitEngine {
         self.id
     }
 
+    fn engine_type(&self) -> EngineType {
+        EngineType::WebKit
+    }
+
     fn dirty(&mut self) -> bool {
         self.dirty
     }
 
-    fn attach_buffer(&mut self, surface: &WlSurface) -> bool {
+    #[cfg_attr(feature = "profiling", profiling::function)]
+    fn draw(&mut self) -> bool {
         self.dirty = false;
 
         // Check for config updates on every frame.
@@ -677,10 +696,13 @@ impl Engine for WebKitEngine {
 
         match &self.buffer {
             Some((buffer, _)) => {
-                surface.attach(Some(buffer), 0, 0);
+                self.surface.attach(Some(buffer), 0, 0);
                 true
             },
-            None => false,
+            None => {
+                self.surface.attach(None, 0, 0);
+                false
+            },
         }
     }
 
@@ -808,6 +830,10 @@ impl Engine for WebKitEngine {
         self.webkit_display.touch(time, id, position, modifiers, EventType::TouchMove);
     }
 
+    fn reload(&mut self) {
+        self.web_view.reload();
+    }
+
     fn load_uri(&mut self, uri: &str) {
         self.web_view.load_uri(uri);
     }
@@ -828,7 +854,7 @@ impl Engine for WebKitEngine {
         self.web_view.title().unwrap_or_default().to_string().into()
     }
 
-    fn text_input_state(&self) -> TextInputChange {
+    fn text_input_state(&mut self) -> TextInputChange {
         self.webkit_display.input_method_context().text_input_state()
     }
 
@@ -853,10 +879,6 @@ impl Engine for WebKitEngine {
 
         self.webkit_display.input_method_context().emit_by_name::<()>("preedit-changed", &[]);
         self.webkit_display.input_method_context().emit_by_name::<()>("preedit-finished", &[]);
-    }
-
-    fn paste(&mut self, text: String) {
-        self.commit_string(text);
     }
 
     fn clear_focus(&mut self) {
@@ -915,15 +937,16 @@ impl Engine for WebKitEngine {
         let height = favicon.height();
 
         (width > 0 && height > 0).then_some(Favicon {
-            resource_uri,
             bytes,
+            id: FaviconId::WebKit(resource_uri),
             width: width as usize,
             height: height as usize,
+            format: gl::BGRA_EXT,
         })
     }
 
     #[cfg_attr(feature = "profiling", profiling::function)]
-    fn favicon_uri(&self) -> Option<glib::GString> {
+    fn favicon_uri(&self) -> Option<GString> {
         let data_manager = self.web_view.network_session()?.website_data_manager()?;
         let favicon_database = data_manager.favicon_database()?;
         favicon_database.favicon_uri(&self.uri())
@@ -1173,24 +1196,25 @@ enum Menu {
 }
 
 impl Menu {
-    /// Number of items in the menu.
-    fn n_items(&self) -> u32 {
+    /// Get option menu items for this menu.
+    fn items(&self) -> Vec<OptionMenuItem> {
         match self {
-            Self::ContextMenu(menu) => menu.n_items(),
-            Self::OptionMenu(menu) => menu.n_items(),
-        }
-    }
-
-    /// Get the item at the specified index.
-    fn item(&self, index: u32) -> Option<MenuItem> {
-        match self {
-            Self::ContextMenu(menu) => {
-                let item = menu.item(index)?;
-                Some(MenuItem::ContextMenuItem(item))
-            },
+            Self::ContextMenu(menu) => menu.items(),
             Self::OptionMenu(menu) => {
-                let item = menu.item(index)?;
-                Some(MenuItem::OptionMenuItem(item))
+                let mut items = Vec::new();
+                for i in 0..menu.n_items() {
+                    if let Some(mut item) = menu.item(i)
+                        && let Some(label) = item.label()
+                    {
+                        items.push(OptionMenuItem {
+                            label: label.into(),
+                            description: String::new(),
+                            disabled: !item.is_enabled(),
+                            selected: item.is_selected(),
+                        });
+                    }
+                }
+                items
             },
         }
     }
@@ -1219,7 +1243,7 @@ impl Menu {
     /// Activate item at the specified position.
     fn activate_item(&self, engine: &mut WebKitEngine, index: u32) {
         match self {
-            Self::ContextMenu(menu) => menu.activate_item(engine, index),
+            Self::ContextMenu(menu) => menu.activate_item(engine.queue.handle(), engine.id, index),
             Self::OptionMenu(menu) => menu.activate_item(index),
         }
     }
@@ -1228,224 +1252,6 @@ impl Menu {
 impl From<&OptionMenu> for Menu {
     fn from(menu: &OptionMenu) -> Menu {
         Self::OptionMenu(menu.clone())
-    }
-}
-
-/// WebKit popup menu item.
-enum MenuItem {
-    /// Right-click menu item.
-    ContextMenuItem(ContextMenuItem),
-    /// Dropdown menu item.
-    OptionMenuItem(WebKitOptionMenuItem),
-}
-
-impl MenuItem {
-    /// Get the text of the item.
-    fn label<'a>(&mut self) -> Option<Cow<'a, str>> {
-        match self {
-            Self::ContextMenuItem(item) => Some(item.label().into()),
-            Self::OptionMenuItem(item) => item.label().map(|label| label.to_string().into()),
-        }
-    }
-
-    /// Check whether an item is enabled.
-    fn is_enabled(&mut self) -> bool {
-        match self {
-            Self::ContextMenuItem(_) => true,
-            Self::OptionMenuItem(item) => item.is_enabled(),
-        }
-    }
-
-    /// Check whether an item is selected.
-    fn is_selected(&mut self) -> bool {
-        match self {
-            Self::ContextMenuItem(_) => false,
-            Self::OptionMenuItem(item) => item.is_selected(),
-        }
-    }
-}
-
-/// Custom context menu based on a hit test.
-#[derive(Debug)]
-struct ContextMenu {
-    hit_test_result: HitTestResult,
-    context: HitTestResultContext,
-    has_cookie_exception: bool,
-    host: Option<GString>,
-}
-
-impl ContextMenu {
-    fn new(cookie_whitelist: &CookieWhitelist, uri: &str, hit_test_result: HitTestResult) -> Self {
-        let context = HitTestResultContext::from_bits(hit_test_result.context())
-            .unwrap_or(HitTestResultContext::empty());
-
-        let mut context_menu = Self {
-            hit_test_result,
-            context,
-            has_cookie_exception: Default::default(),
-            host: Default::default(),
-        };
-
-        // Set correct cookie exception message if we are going to display it.
-        if context == HitTestResultContext::DOCUMENT
-            && let Some(host) = Uri::parse(uri, UriFlags::NONE).ok().and_then(|uri| uri.host())
-        {
-            context_menu.has_cookie_exception = cookie_whitelist.contains(&host);
-            context_menu.host = Some(host);
-        }
-
-        context_menu
-    }
-
-    /// Number of items in the menu.
-    fn n_items(&self) -> u32 {
-        let mut n_items = 0;
-
-        // Only show these entries without any targeted element.
-        if self.context == HitTestResultContext::DOCUMENT {
-            n_items += 2;
-        }
-
-        if self.context.contains(HitTestResultContext::DOCUMENT) {
-            n_items += 1;
-        }
-
-        if self.context.intersects(
-            HitTestResultContext::LINK | HitTestResultContext::IMAGE | HitTestResultContext::MEDIA,
-        ) {
-            n_items += 3;
-        }
-
-        if self.context.contains(HitTestResultContext::EDITABLE) {
-            n_items += 1;
-        }
-
-        n_items
-    }
-
-    /// Get the item at the specified index.
-    #[allow(clippy::single_match)]
-    fn item(&self, mut index: u32) -> Option<ContextMenuItem> {
-        // Only show these entries without any targeted element.
-        if self.context == HitTestResultContext::DOCUMENT {
-            match index {
-                0 if self.has_cookie_exception => {
-                    return Some(ContextMenuItem::RemoveCookieException);
-                },
-                0 => return Some(ContextMenuItem::AddCookieException),
-                1 => return Some(ContextMenuItem::Search),
-                _ => (),
-            }
-            index -= 2;
-        }
-
-        if self.context.contains(HitTestResultContext::DOCUMENT) {
-            match index {
-                0 => return Some(ContextMenuItem::Reload),
-                _ => (),
-            }
-            index -= 1;
-        }
-
-        if self.context.intersects(
-            HitTestResultContext::LINK | HitTestResultContext::IMAGE | HitTestResultContext::MEDIA,
-        ) {
-            match index {
-                0 => return Some(ContextMenuItem::CopyLink),
-                1 => return Some(ContextMenuItem::OpenInNewWindow),
-                2 => return Some(ContextMenuItem::OpenInNewTab),
-                _ => (),
-            }
-            index -= 3;
-        }
-
-        if self.context.contains(HitTestResultContext::EDITABLE) {
-            match index {
-                0 => return Some(ContextMenuItem::Paste),
-                _ => (),
-            }
-            // index -= 1;
-        }
-
-        None
-    }
-
-    /// Activate item at the specified position.
-    fn activate_item(&self, engine: &mut WebKitEngine, index: u32) {
-        match self.item(index) {
-            Some(ContextMenuItem::AddCookieException) => {
-                if let Some(host) = &self.host {
-                    engine.queue.add_cookie_exception(host.to_string());
-                }
-            },
-            Some(ContextMenuItem::RemoveCookieException) => {
-                if let Some(host) = &self.host {
-                    engine.queue.remove_cookie_exception(host.to_string());
-                }
-            },
-            Some(ContextMenuItem::Search) => engine.queue.start_search(engine.id),
-            Some(ContextMenuItem::Reload) => engine.web_view.reload(),
-            Some(ContextMenuItem::OpenInNewTab) => {
-                if let Some(uri) = self.uri() {
-                    engine.queue.open_in_tab(engine.id, uri);
-                }
-            },
-            Some(ContextMenuItem::OpenInNewWindow) => {
-                if let Some(uri) = self.uri() {
-                    engine.queue.open_in_window(engine.id, uri);
-                }
-            },
-            Some(ContextMenuItem::CopyLink) => {
-                if let Some(uri) = self.uri() {
-                    engine.queue.set_clipboard(uri);
-                }
-            },
-            Some(ContextMenuItem::Paste) => {
-                engine.queue.request_paste(PasteTarget::Browser(engine.id()))
-            },
-            None => (),
-        }
-    }
-
-    /// Get URI for the context menu's target resourc.
-    fn uri(&self) -> Option<String> {
-        if self.context.contains(HitTestResultContext::LINK) {
-            self.hit_test_result.link_uri().map(String::from)
-        } else if self.context.contains(HitTestResultContext::IMAGE) {
-            self.hit_test_result.image_uri().map(String::from)
-        } else if self.context.contains(HitTestResultContext::MEDIA) {
-            self.hit_test_result.media_uri().map(String::from)
-        } else {
-            None
-        }
-    }
-}
-
-/// Custom context menu item based on a hit test.
-#[derive(Debug)]
-enum ContextMenuItem {
-    AddCookieException,
-    RemoveCookieException,
-    Reload,
-    OpenInNewTab,
-    OpenInNewWindow,
-    CopyLink,
-    Paste,
-    Search,
-}
-
-impl ContextMenuItem {
-    fn label(&self) -> &'static str {
-        match self {
-            Self::AddCookieException => "Add Cookie Exception",
-            Self::RemoveCookieException => "Remove Cookie Exception",
-            Self::Reload => "Reload",
-            Self::OpenInNewTab => "Open in New Tab",
-            Self::OpenInNewWindow => "Open in New Window",
-            Self::CopyLink => "Copy Link",
-            Self::Paste => "Paste",
-            Self::Search => "Search Page",
-        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::io::Read;
@@ -6,7 +5,6 @@ use std::num::{ParseFloatError, ParseIntError};
 use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 use std::os::fd::{AsFd, AsRawFd};
 use std::ptr::NonNull;
-use std::rc::Rc;
 use std::time::Duration;
 use std::{env, io, mem, process};
 
@@ -14,6 +12,10 @@ use clap::Parser;
 use cli::{ConfigOptions, Options, Subcommands};
 use configory::Manager as ConfigManager;
 use configory::ipc::Ipc;
+#[cfg(feature = "servo")]
+use dpi::PhysicalSize;
+#[cfg(feature = "servo")]
+use euclid::Point2D;
 use funq::{MtQueueHandle, Queue, StQueueHandle};
 use glib::{ControlFlow, IOCondition, MainLoop, Priority, Source, source};
 use glutin::display::{Display, DisplayApiPreference};
@@ -22,6 +24,8 @@ use profiling::puffin;
 #[cfg(feature = "profiling")]
 use puffin_http::Server;
 use raw_window_handle::{RawDisplayHandle, WaylandDisplayHandle};
+#[cfg(feature = "servo")]
+use servo::WebViewPoint;
 use smithay_client_toolkit::data_device_manager::data_source::CopyPasteSource;
 use smithay_client_toolkit::reexports::client::globals::{self, BindError, GlobalError};
 use smithay_client_toolkit::reexports::client::protocol::wl_keyboard::WlKeyboard;
@@ -36,8 +40,11 @@ use tracing::{error, info, warn};
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 use crate::config::ConfigEventHandler;
+#[cfg(feature = "servo")]
+use crate::engine::servo::ServoState;
+#[cfg(feature = "webkit")]
 use crate::engine::webkit::{WebKitError, WebKitState};
-use crate::engine::{Group, GroupId, NO_GROUP_ID};
+use crate::engine::{Group, NO_GROUP_ID, OnDemandState};
 use crate::storage::Storage;
 use crate::storage::history::History;
 use crate::wayland::WaylandDispatch;
@@ -57,6 +64,9 @@ mod gl {
     include!(concat!(env!("OUT_DIR"), "/gl_bindings.rs"));
 }
 
+#[cfg(not(any(feature = "servo", feature = "webkit")))]
+compile_error!("At least one browser engine feature must be enabled.");
+
 #[derive(thiserror::Error, Debug)]
 enum Error {
     #[error("{0}")]
@@ -64,21 +74,22 @@ enum Error {
     #[error("Wayland protocol error for {0}: {1}")]
     WaylandProtocol(&'static str, #[source] BindError),
     #[error("{0}")]
-    ParseFloatError(#[from] ParseFloatError),
-    #[error("{0}")]
-    ParseIntError(#[from] ParseIntError),
-    #[error("{0}")]
     Deserialize(#[from] toml::de::Error),
     #[error("{0}")]
     Glutin(#[from] glutin::error::Error),
+    #[error("{0}")]
+    ParseFloat(#[from] ParseFloatError),
     #[error("{0}")]
     WaylandGlobal(#[from] GlobalError),
     #[error("{0}")]
     Config(#[from] configory::Error),
     #[error("{0}")]
-    WebKit(#[from] WebKitError),
+    ParseInt(#[from] ParseIntError),
     #[error("{0}")]
     Sql(#[from] rusqlite::Error),
+    #[cfg(feature = "webkit")]
+    #[error("{0}")]
+    WebKit(#[from] WebKitError),
     #[error("{0}")]
     Io(#[from] io::Error),
     #[error("local database version ({0}) is higher than latest supported version ({1})")]
@@ -133,48 +144,36 @@ fn run() -> Result<(), Error> {
     let main_loop = MainLoop::new(None, true);
     let mut state = State::new(queue.local_handle(), main_loop.clone())?;
 
-    // Create our initial window.
-    let root_window = state.create_window();
-    let root_window_id = root_window.id();
-
-    // Create initial browser tab.
-    root_window.add_tab(true, true, NO_GROUP_ID);
-
-    // Ensure Wayland processing is kicked off.
-    state.wayland_dispatch();
-
-    // Create an empty tab for loading a new page.
-    let mut is_first_tab = true;
-    let get_empty_tab =
-        |window: &mut Window, is_first_tab: &mut bool, group_id: GroupId, focus: bool| -> _ {
-            if *is_first_tab && group_id == NO_GROUP_ID {
-                window.set_keyboard_focus(KeyboardFocus::None);
-                *is_first_tab = false;
-                window.active_tab().unwrap().id()
-            } else {
-                window.add_tab(false, focus, group_id)
-            }
-        };
-
     // Get all sessions requiring restoration, sorted by PID and window ID.
+    //
+    // XXX: This must be retrieved before the first engine creation,
+    // so the initial tab isn't counted as an orphan session.
     let mut orphan_sessions = state.storage.session.orphans();
     orphan_sessions.sort_by(|a, b| match a.pid.cmp(&b.pid) {
         Ordering::Equal => a.window_id.cmp(&b.window_id),
         ordering => ordering,
     });
 
+    // Create initial window.
+    let root_window_id = state.create_window().id();
+
     // Restore all orphan sessions.
     let mut window = state.windows.get_mut(&root_window_id).unwrap();
     let mut session_window_id = None;
+    let mut is_first_tab = true;
     let mut session_pid = None;
     for entry in &mut orphan_sessions {
+        // Ignore empty tabs for session recover.
+        if entry.uri.is_empty() || entry.uri == "about:blank" {
+            continue;
+        }
+
         // Create new window if session's process or window changed.
         if session_pid != Some(entry.pid) || session_window_id != Some(entry.window_id) {
             // Create a new window.
             if session_pid.is_some() || session_window_id.is_some() {
                 let new_window_id = state.create_window().id();
                 window = state.windows.get_mut(&new_window_id).unwrap();
-                window.add_tab(true, true, NO_GROUP_ID);
                 is_first_tab = true;
             }
 
@@ -193,18 +192,14 @@ fn run() -> Result<(), Error> {
         };
 
         // Restore the session in a new empty tab.
-        let engine_id = get_empty_tab(window, &mut is_first_tab, group_id, entry.focused);
+        let focus_tab = mem::take(&mut is_first_tab) || entry.focused;
+        let engine_id = window.add_tab(false, focus_tab, group_id, Some(&entry.uri));
         if let Some(engine) = window.tab_mut(engine_id) {
             engine.restore_session(mem::take(&mut entry.session_data));
-            engine.load_uri(&entry.uri);
         }
     }
 
     // Update database with the adopted sessions.
-    //
-    // NOTE: Calling `load_uri` automatically causes the session to be persisted
-    // once the page is loaded, however we explicitly sync here to avoid session
-    // loss due to a racing condition.
     for window in state.windows.values() {
         window.persist_session();
     }
@@ -213,9 +208,19 @@ fn run() -> Result<(), Error> {
     // Spawn a new tab for every CLI argument.
     let root_window = state.windows.get_mut(&root_window_id).unwrap();
     for arg in options.links {
-        get_empty_tab(root_window, &mut is_first_tab, NO_GROUP_ID, true);
+        root_window.add_tab(false, true, NO_GROUP_ID, None);
         root_window.load_uri(arg, true);
     }
+
+    // Ensure at least one tab exists.
+    if !root_window.has_tabs() {
+        root_window.add_tab(true, true, NO_GROUP_ID, None);
+    }
+
+    // Ensure Wayland processing is kicked off.
+    //
+    // XXX: This must happen *AFTER* the first tab is created.
+    state.wayland_dispatch();
 
     // Register Wayland socket with GLib event loop.
     let mut queue_handle = queue.handle();
@@ -322,6 +327,7 @@ pub struct State {
     wayland_queue: Option<EventQueue<Self>>,
     protocol_states: ProtocolStates,
     connection: Connection,
+
     egl_display: Display,
 
     text_input: Vec<TextInput>,
@@ -334,7 +340,10 @@ pub struct State {
     keyboard_focus: Option<WindowId>,
     touch_focus: Option<(WindowId, WlSurface)>,
 
-    engine_state: Rc<RefCell<WebKitState>>,
+    #[cfg(feature = "webkit")]
+    webkit_state: OnDemandState<WebKitState>,
+    #[cfg(feature = "servo")]
+    servo_state: OnDemandState<ServoState>,
 
     config_manager: ConfigManager<ConfigEventHandler>,
     storage: Storage,
@@ -360,18 +369,37 @@ impl State {
 
         let storage = Storage::new()?;
 
-        let engine_state = Rc::new(RefCell::new(WebKitState::new(
-            egl_display.clone(),
-            queue.clone(),
-            storage.cookie_whitelist.clone(),
-            &storage.groups.all_group_ids(),
-        )));
+        #[cfg(feature = "webkit")]
+        let webkit_state = {
+            // Get the DRM render node.
+            let Display::Egl(egl_display) = &egl_display;
+            let device = egl_display.device().expect("get DRM device");
+            let device_node = device.drm_device_node_path().expect("DRM node has no path").into();
+
+            let webkit_cookie_whitelist = storage.cookie_whitelist.clone();
+            let group_ids = storage.groups.all_group_ids();
+            let webkit_queue = queue.clone();
+            OnDemandState::new(Box::new(move || {
+                WebKitState::new(device_node, webkit_queue, webkit_cookie_whitelist, &group_ids)
+            }))
+        };
+        #[cfg(feature = "servo")]
+        let servo_state = {
+            let servo_cookie_whitelist = storage.cookie_whitelist.clone();
+            let servo_queue = queue.handle();
+            OnDemandState::new(Box::new(move || {
+                ServoState::new(raw_display, servo_queue, servo_cookie_whitelist)
+            }))
+        };
 
         Ok(Self {
             protocol_states,
             config_manager,
-            engine_state,
+            #[cfg(feature = "webkit")]
+            webkit_state,
             egl_display,
+            #[cfg(feature = "servo")]
+            servo_state,
             connection,
             main_loop,
             storage,
@@ -397,7 +425,10 @@ impl State {
             self.queue.clone(),
             self.wayland_queue(),
             &self.storage,
-            self.engine_state.clone(),
+            #[cfg(feature = "webkit")]
+            self.webkit_state.clone(),
+            #[cfg(feature = "servo")]
+            self.servo_state.clone(),
         );
         self.windows.entry(window.id()).insert_entry(window).into_mut()
     }
@@ -439,13 +470,14 @@ impl State {
 
         // Asynchronously write paste text to the window.
         let mut queue = self.queue.clone();
+        let mut target = Some(target);
         source::unix_fd_add_local(pipe.as_raw_fd(), IOCondition::IN, move |_, _| {
             // Read available text from pipe.
             let mut text = String::new();
             pipe.read_to_string(&mut text).unwrap();
 
             // Forward text to the paste target.
-            queue.paste(target, text);
+            queue.paste(target.take().unwrap(), text);
 
             ControlFlow::Break
         });
@@ -604,6 +636,27 @@ impl From<Position<f64>> for Position<f32> {
     }
 }
 
+#[cfg(feature = "servo")]
+impl<T, U> From<Point2D<T, U>> for Position<T> {
+    fn from(point: Point2D<T, U>) -> Self {
+        Self::new(point.x, point.y)
+    }
+}
+
+#[cfg(feature = "servo")]
+impl<T, U> From<Position<T>> for Point2D<T, U> {
+    fn from(position: Position<T>) -> Self {
+        Point2D::new(position.x, position.y)
+    }
+}
+
+#[cfg(feature = "servo")]
+impl From<Position<f64>> for WebViewPoint {
+    fn from(position: Position<f64>) -> Self {
+        WebViewPoint::Device(Point2D::new(position.x as f32, position.y as f32))
+    }
+}
+
 impl Mul<f64> for Position {
     type Output = Self;
 
@@ -706,6 +759,20 @@ impl From<Size> for Size<f64> {
 impl From<Size> for Size<f32> {
     fn from(size: Size) -> Self {
         Self { width: size.width as f32, height: size.height as f32 }
+    }
+}
+
+#[cfg(feature = "servo")]
+impl<T> From<PhysicalSize<T>> for Size<T> {
+    fn from(physical: PhysicalSize<T>) -> Self {
+        Self { width: physical.width, height: physical.height }
+    }
+}
+
+#[cfg(feature = "servo")]
+impl<T> From<Size<T>> for PhysicalSize<T> {
+    fn from(size: Size<T>) -> Self {
+        Self { width: size.width, height: size.height }
     }
 }
 

--- a/src/storage/cookie_whitelist.rs
+++ b/src/storage/cookie_whitelist.rs
@@ -20,6 +20,7 @@ impl CookieWhitelist {
     }
 
     /// Get all allowed hosts.
+    #[cfg(feature = "webkit")]
     pub fn hosts(&self) -> Vec<String> {
         let connection = match &self.connection {
             Some(connection) => connection,

--- a/src/storage/engine_preference.rs
+++ b/src/storage/engine_preference.rs
@@ -1,0 +1,218 @@
+//! Host-based browser engine preference.
+
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::RwLock;
+
+use rusqlite::{Connection as SqliteConnection, Transaction};
+use tracing::error;
+use url::Url;
+
+use crate::engine::EngineType;
+use crate::storage::DbVersion;
+
+/// Host-based browser engine preference.
+#[derive(Clone)]
+pub struct EnginePreference {
+    preferences: Rc<RwLock<HashMap<String, EngineType>>>,
+    #[cfg_attr(not(all(feature = "servo", feature = "webkit")), expect(unused))]
+    db: Option<EnginePreferenceDb>,
+}
+
+impl EnginePreference {
+    #[cfg_attr(feature = "profiling", profiling::function)]
+    pub fn new(connection: Option<Rc<SqliteConnection>>) -> Self {
+        let (db, preferences) = match connection {
+            Some(connection) => {
+                let db = EnginePreferenceDb::new(connection);
+                let preferences = db.preferences().unwrap_or_default();
+                (Some(db), Rc::new(RwLock::new(preferences)))
+            },
+            None => (None, Default::default()),
+        };
+
+        Self { preferences, db }
+    }
+
+    /// Get engine preference for a host.
+    #[cfg_attr(feature = "profiling", profiling::function)]
+    pub fn get(&self, url: &str) -> Option<EngineType> {
+        let url = Url::parse(url).ok()?;
+        let host = url.host_str()?;
+
+        self.preferences.read().unwrap().get(host).copied()
+    }
+
+    /// Add a new engine preference for a host.
+    #[cfg(all(feature = "servo", feature = "webkit"))]
+    #[cfg_attr(feature = "profiling", profiling::function)]
+    pub fn set(&self, url: &str, engine_type: EngineType) {
+        // Ignore URLs without valid host.
+        let url = Url::parse(url).ok();
+        let host = match url.as_ref().and_then(|url| url.host_str()) {
+            Some(host) => host,
+            None => return,
+        };
+
+        // Update the database.
+        if let Some(db) = &self.db {
+            db.set(host, engine_type)
+        };
+
+        // Update the cache.
+        let mut preferences = self.preferences.write().unwrap();
+        preferences.insert(host.to_string(), engine_type);
+    }
+}
+
+/// Host-based browser engine preference.
+#[derive(Clone)]
+struct EnginePreferenceDb {
+    connection: Rc<SqliteConnection>,
+}
+
+impl EnginePreferenceDb {
+    fn new(connection: Rc<SqliteConnection>) -> Self {
+        Self { connection }
+    }
+
+    /// Get all current host engine preferences.
+    #[cfg_attr(feature = "profiling", profiling::function)]
+    fn preferences(&self) -> Option<HashMap<String, EngineType>> {
+        let mut stmt = self
+            .connection
+            .prepare("SELECT host, engine_type FROM engine_preference")
+            .inspect_err(|err| error!("Failed to prepare SQL query: {err}"))
+            .ok()?;
+
+        let preferences = stmt
+            .query_map([], |row| {
+                let host = row.get(0)?;
+                let engine_type = row.get(1)?;
+                Ok((host, engine_type))
+            })
+            .inspect_err(|err| error!("Failed to get engine preferences: {err}"))
+            .ok()?
+            .flatten()
+            .collect();
+
+        Some(preferences)
+    }
+
+    /// Update the preferred engine for a host.
+    #[cfg(all(feature = "servo", feature = "webkit"))]
+    #[cfg_attr(feature = "profiling", profiling::function)]
+    fn set(&self, host: &str, engine_type: EngineType) {
+        let mut stmt = match self.connection.prepare_cached(
+            "INSERT INTO engine_preference (host, engine_type) VALUES (?1, ?2) ON CONFLICT(host) \
+             DO UPDATE SET engine_type = ?2",
+        ) {
+            Ok(stmt) => stmt,
+            Err(err) => {
+                error!("Failed to prepare SQL query: {err}");
+                return;
+            },
+        };
+
+        let _ = stmt
+            .execute((host, engine_type))
+            .inspect_err(|err| error!("Failed to set engine preference: {err}"));
+    }
+}
+
+/// Run database migrations inside a transaction.
+pub fn run_migrations(
+    transaction: &Transaction<'_>,
+    db_version: DbVersion,
+) -> rusqlite::Result<()> {
+    // Create table if it doesn't exist yet.
+    if db_version < DbVersion::Three {
+        transaction.execute(
+            "CREATE TABLE IF NOT EXISTS engine_preference (
+                host TEXT NOT NULL,
+                engine_type TEXT NOT NULL,
+                UNIQUE(host)
+            )",
+            [],
+        )?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    #[cfg(all(feature = "servo", feature = "webkit"))]
+    #[test]
+    fn cached_preference() {
+        let engine_preference = EnginePreference::new(None);
+
+        assert_eq!(engine_preference.get("https://example.org"), None);
+
+        engine_preference.set("https://example.org", EngineType::Servo);
+        assert_eq!(engine_preference.get("https://example.org"), Some(EngineType::Servo));
+
+        engine_preference.set("https://example.org", EngineType::WebKit);
+        assert_eq!(engine_preference.get("https://example.org"), Some(EngineType::WebKit));
+    }
+
+    #[test]
+    fn sqlite_preference_load() {
+        // Prepare test database.
+        let db_file = NamedTempFile::new().unwrap();
+        let mut connection = Connection::open(&db_file).unwrap();
+        let transaction = connection.transaction().unwrap();
+        run_migrations(&transaction, DbVersion::Zero).unwrap();
+        transaction.commit().unwrap();
+
+        // Manually insert initial engine preferences.
+        connection
+            .execute(
+                "INSERT INTO engine_preference (host, engine_type) VALUES ('example.org', \
+                 'servo'), ('catacombing.org', 'webkit')",
+                [],
+            )
+            .unwrap();
+
+        // Ensure preferences are loaded correctly.
+        let engine_preference = EnginePreference::new(Some(Rc::new(connection)));
+        assert_eq!(engine_preference.get("https://example.org"), Some(EngineType::Servo));
+        assert_eq!(engine_preference.get("https://catacombing.org"), Some(EngineType::WebKit));
+        assert_eq!(engine_preference.get("https://alacritty.org"), None);
+    }
+
+    #[cfg(all(feature = "servo", feature = "webkit"))]
+    #[test]
+    fn update_through_cache() {
+        // Prepare test database.
+        let db_file = NamedTempFile::new().unwrap();
+        let mut connection = Connection::open(&db_file).unwrap();
+        let transaction = connection.transaction().unwrap();
+        run_migrations(&transaction, DbVersion::Zero).unwrap();
+        transaction.commit().unwrap();
+
+        // Engine type is initially undefined.
+        let connection = Rc::new(connection);
+        let engine_preference = EnginePreference::new(Some(connection.clone()));
+        assert_eq!(engine_preference.get("https://example.org"), None);
+
+        // Update the cached value.
+        engine_preference.set("https://example.org", EngineType::Servo);
+        assert_eq!(engine_preference.get("https://example.org"), Some(EngineType::Servo));
+
+        // Data is persisted to the database.
+        let engine_type: EngineType = connection
+            .query_one(
+                "SELECT engine_type FROM engine_preference WHERE host = 'example.org'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(engine_type, EngineType::Servo);
+    }
+}

--- a/src/storage/groups.rs
+++ b/src/storage/groups.rs
@@ -1,5 +1,6 @@
 //! Tab groups DB storage.
 
+#[cfg(feature = "webkit")]
 use std::collections::HashSet;
 use std::rc::Rc;
 
@@ -67,6 +68,7 @@ impl Groups {
     }
 
     /// Get all known group IDs.
+    #[cfg(feature = "webkit")]
     pub fn all_group_ids(&self) -> HashSet<Uuid> {
         let db = match &self.db {
             Some(db) => db,
@@ -131,6 +133,7 @@ impl GroupsDb {
     }
 
     /// Get group IDs for all PIDs and windows.
+    #[cfg(feature = "webkit")]
     #[cfg_attr(feature = "profiling", profiling::function)]
     fn all_group_ids(&self) -> rusqlite::Result<HashSet<Uuid>> {
         let mut statement = self.connection.prepare("SELECT id FROM tab_group")?;

--- a/src/storage/history.rs
+++ b/src/storage/history.rs
@@ -485,25 +485,23 @@ pub fn run_migrations(
     transaction: &Transaction<'_>,
     db_version: DbVersion,
 ) -> rusqlite::Result<()> {
-    match db_version {
-        // Create table if it doesn't exist yet.
-        DbVersion::Zero => {
-            let _ = transaction.execute(
-                "CREATE TABLE IF NOT EXISTS history (
+    // Create table if it doesn't exist yet.
+    if db_version == DbVersion::Zero {
+        let _ = transaction.execute(
+            "CREATE TABLE IF NOT EXISTS history (
                     uri TEXT NOT NULL PRIMARY KEY,
                     title TEXT DEFAULT '',
                     views INTEGER NOT NULL DEFAULT 1,
                     last_access INTEGER NOT NULL
                 )",
-                [],
-            )?;
-        },
-        // Delete all file/data URIs, since they were persisted incorrectly.
-        DbVersion::One => {
-            let _ = transaction.execute("DELETE FROM history WHERE uri LIKE 'file:%'", [])?;
-            let _ = transaction.execute("DELETE FROM history WHERE uri LIKE 'data:%'", [])?;
-        },
-        _ => (),
+            [],
+        )?;
+    }
+
+    // Delete all file/data URIs, since they were persisted incorrectly.
+    if db_version < DbVersion::Two {
+        let _ = transaction.execute("DELETE FROM history WHERE uri LIKE 'file:%'", [])?;
+        let _ = transaction.execute("DELETE FROM history WHERE uri LIKE 'data:%'", [])?;
     }
 
     Ok(())

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -8,17 +8,20 @@ use tracing::error;
 
 use crate::Error;
 use crate::storage::cookie_whitelist::CookieWhitelist;
+use crate::storage::engine_preference::EnginePreference;
 use crate::storage::groups::Groups;
 use crate::storage::history::History;
 use crate::storage::session::Session;
 
 pub mod cookie_whitelist;
+pub mod engine_preference;
 pub mod groups;
 pub mod history;
 pub mod session;
 
 /// Persistent data storage.
 pub struct Storage {
+    pub engine_preference: EnginePreference,
     pub cookie_whitelist: CookieWhitelist,
     pub history: History,
     pub session: Session,
@@ -47,6 +50,7 @@ impl Storage {
             let transaction = connection.transaction()?;
 
             // Run table migrations.
+            engine_preference::run_migrations(&transaction, version)?;
             cookie_whitelist::run_migrations(&transaction, version)?;
             history::run_migrations(&transaction, version)?;
             session::run_migrations(&transaction, version)?;
@@ -59,12 +63,13 @@ impl Storage {
         }
 
         let connection = connection.map(Rc::new);
+        let engine_preference = EnginePreference::new(connection.clone());
         let cookie_whitelist = CookieWhitelist::new(connection.clone());
         let history = History::new(connection.clone())?;
         let session = Session::new(connection.clone());
         let groups = Groups::new(connection.clone());
 
-        Ok(Self { cookie_whitelist, history, session, groups })
+        Ok(Self { engine_preference, cookie_whitelist, history, session, groups })
     }
 
     /// Attempt to create or access the SQLite database.
@@ -100,6 +105,7 @@ impl Storage {
             None | Some(0) => Ok(DbVersion::Zero),
             Some(1) => Ok(DbVersion::One),
             Some(2) => Ok(DbVersion::Two),
+            Some(3) => Ok(DbVersion::Three),
             // Report an error if the DB version is newer than expected.
             Some(version) => {
                 let latest_version = DbVersion::Unknown as u8 - 1;
@@ -144,13 +150,14 @@ impl Storage {
 ///
 /// This version is used to detect the current database state and automatically
 /// migrate tables when required.
-#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+#[derive(PartialOrd, Ord, PartialEq, Eq, Copy, Clone, Debug)]
 pub enum DbVersion {
     /// Any version before versioning was introduced.
     Zero,
     /// First versioned database.
     One,
     Two,
+    Three,
 
     /// XXX: Used to determine incompatible DB versions,
     /// this **must** always be the last field.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -28,7 +28,7 @@ use crate::{History, Position, Size, State, WindowId, gl, rect_contains};
 
 pub mod engine_backdrop;
 pub mod overlay;
-mod renderer;
+pub mod renderer;
 
 /// Logical height of the non-browser UI.
 pub const TOOLBAR_HEIGHT: u32 = 50;
@@ -229,7 +229,7 @@ impl Ui {
         let uribar = Uribar::new(window_id, history, queue.clone());
         let renderer = Renderer::new(display, surface.clone());
 
-        let mut ui = Self {
+        Self {
             compositor,
             subsurface,
             window_id,
@@ -257,12 +257,7 @@ impl Ui {
             origin: Default::default(),
             dirty: Default::default(),
             size: Default::default(),
-        };
-
-        // Focus URI bar on window creation.
-        ui.keyboard_focus_uribar();
-
-        ui
+        }
     }
 
     /// Update the logical UI size.
@@ -659,6 +654,7 @@ impl Ui {
     }
 
     /// Update the current number of search matches.
+    #[cfg(feature = "webkit")]
     pub fn set_search_match_count(&mut self, count: usize) {
         let has_matches = count != 0 || self.uribar.text_field.is_empty();
         self.dirty |= self.uribar.search_has_matches != has_matches;
@@ -871,7 +867,15 @@ impl Uribar {
     }
 
     /// Update the URI bar's content.
-    fn set_uri(&mut self, uri: Cow<'_, str>) {
+    fn set_uri(&mut self, mut uri: Cow<'_, str>) {
+        // Display about:blank as empty URI.
+        //
+        // This ensures that a new tab's URI can easily be changed,
+        // without having to clear the about:blank text first.
+        if uri == "about:blank" {
+            uri = Cow::Borrowed("");
+        }
+
         if uri == self.uri {
             return;
         }
@@ -1393,6 +1397,7 @@ impl TextField {
     }
 
     /// Check if the input's text is empty.
+    #[cfg(feature = "webkit")]
     #[cfg_attr(feature = "profiling", profiling::function)]
     fn is_empty(&self) -> bool {
         self.layout.text().is_empty()

--- a/src/ui/overlay/downloads.rs
+++ b/src/ui/overlay/downloads.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::mem;
 use std::path::PathBuf;
+#[cfg(feature = "webkit")]
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use funq::MtQueueHandle;
@@ -103,6 +104,7 @@ impl Downloads {
     }
 
     /// Add a new download.
+    #[cfg(feature = "webkit")]
     pub fn add_download(&mut self, download: Download) {
         self.texture_cache.entries.insert(download.id, download);
         self.dirty = true;
@@ -112,6 +114,7 @@ impl Downloads {
     ///
     /// A progress value of `None` indicates that the download has failed and
     /// will not make any further progress.
+    #[cfg(feature = "webkit")]
     pub fn set_download_progress(&mut self, download_id: DownloadId, progress: Option<u8>) {
         if let Some(download) = self.texture_cache.entries.get_mut(&download_id) {
             match progress {
@@ -703,6 +706,7 @@ pub struct DownloadId {
 }
 
 impl DownloadId {
+    #[cfg(feature = "webkit")]
     pub fn new(engine_id: EngineId) -> Self {
         static NEXT_DOWNLOAD_ID: AtomicUsize = AtomicUsize::new(0);
         let id = NEXT_DOWNLOAD_ID.fetch_add(1, Ordering::Relaxed);

--- a/src/ui/overlay/history.rs
+++ b/src/ui/overlay/history.rs
@@ -71,10 +71,7 @@ impl HistoryHandler for State {
             None => return,
         };
 
-        let tab_id = window.add_tab(false, true, NO_GROUP_ID);
-        if let Some(engine) = window.tab_mut(tab_id) {
-            engine.load_uri(&uri);
-        }
+        window.add_tab(false, true, NO_GROUP_ID, Some(&uri));
     }
 }
 

--- a/src/ui/overlay/mod.rs
+++ b/src/ui/overlay/mod.rs
@@ -7,9 +7,12 @@ use smithay_client_toolkit::reexports::client::protocol::wl_surface::WlSurface;
 use smithay_client_toolkit::reexports::protocols::wp::viewporter::client::wp_viewport::WpViewport;
 use smithay_client_toolkit::seat::keyboard::{Keysym, Modifiers};
 
+use crate::engine::EngineId;
 use crate::storage::history::History as HistoryDb;
 use crate::ui::Renderer;
-use crate::ui::overlay::downloads::{Download, DownloadId, Downloads};
+use crate::ui::overlay::downloads::Downloads;
+#[cfg(feature = "webkit")]
+use crate::ui::overlay::downloads::{Download, DownloadId};
 use crate::ui::overlay::history::History;
 use crate::ui::overlay::menu::Menu;
 use crate::ui::overlay::option_menu::{
@@ -400,6 +403,7 @@ impl Overlay {
     }
 
     /// Add a new download.
+    #[cfg(feature = "webkit")]
     pub fn add_download(&mut self, download: Download) {
         self.popups.downloads.add_download(download);
     }
@@ -408,6 +412,7 @@ impl Overlay {
     ///
     /// A progress value of `None` indicates that the download has failed and
     /// will not make any further progress.
+    #[cfg(feature = "webkit")]
     pub fn set_download_progress(&mut self, download_id: DownloadId, progress: Option<u8>) {
         self.popups.downloads.set_download_progress(download_id, progress);
     }
@@ -467,8 +472,16 @@ impl Overlay {
 
     /// Permanently discard an option menu.
     pub fn close_option_menu(&mut self, id: OptionMenuId) {
+        let old_len = self.popups.option_menus.len();
         self.popups.option_menus.retain(|menu| menu.id() != id);
-        self.dirty = true;
+        self.dirty |= old_len != self.popups.option_menus.len();
+    }
+
+    /// Remove all option menus associated with an engine.
+    pub fn close_engine_menus(&mut self, engine_id: EngineId) {
+        let old_len = self.popups.option_menus.len();
+        self.popups.option_menus.retain(|menu| menu.id().engine_id() != Some(engine_id));
+        self.dirty |= old_len != self.popups.option_menus.len();
     }
 
     /// Reload settings UI's values from current config.

--- a/src/ui/overlay/option_menu.rs
+++ b/src/ui/overlay/option_menu.rs
@@ -853,7 +853,7 @@ impl OptionMenuPosition {
 
 impl From<Position> for OptionMenuPosition {
     fn from(position: Position) -> Self {
-        Self { position, anchor: Anchor::default() }
+        Self { position, anchor: Default::default() }
     }
 }
 

--- a/src/ui/overlay/tabs.rs
+++ b/src/ui/overlay/tabs.rs
@@ -13,7 +13,7 @@ use pangocairo::pango::Alignment;
 use smithay_client_toolkit::seat::keyboard::{Keysym, Modifiers};
 
 use crate::config::CONFIG;
-use crate::engine::{Engine, EngineId, Favicon, Group, GroupId, NO_GROUP, NO_GROUP_ID};
+use crate::engine::{Engine, EngineId, Favicon, FaviconId, Group, GroupId, NO_GROUP, NO_GROUP_ID};
 use crate::ui::overlay::Popup;
 use crate::ui::renderer::{Renderer, Svg, TextLayout, TextOptions, Texture, TextureBuilder};
 use crate::ui::{ScrollVelocity, SvgButton, TextField};
@@ -96,7 +96,7 @@ impl TabsHandler for State {
             None => return,
         };
 
-        let _ = window.add_tab(true, true, group_id);
+        window.add_tab(true, true, group_id, None);
         window.set_tabs_ui_visible(false);
     }
 
@@ -372,6 +372,7 @@ impl Tabs {
     }
 
     /// Set a tab's audio playback state.
+    #[cfg(feature = "webkit")]
     pub fn set_audio_playing(&mut self, engine_id: EngineId, playing: bool) {
         self.dirty |= self.texture_cache.set_audio_playing(engine_id, playing);
     }
@@ -1191,7 +1192,7 @@ impl Popup for Tabs {
 #[derive(Default)]
 struct TextureCache {
     textures: HashMap<TabTextureCacheKey<'static>, Texture>,
-    favicons: HashMap<glib::GString, Texture>,
+    favicons: HashMap<FaviconId, Texture>,
     tabs: IndexMap<EngineId, RenderTab>,
     resized: bool,
 }
@@ -1231,6 +1232,7 @@ impl TextureCache {
     }
 
     /// Update a tab's audio playback state.
+    #[cfg(feature = "webkit")]
     fn set_audio_playing(&mut self, engine_id: EngineId, playing: bool) -> bool {
         match self.tabs.get_mut(&engine_id) {
             Some(tab) if tab.audio_playing != playing => {
@@ -1251,18 +1253,19 @@ impl TextureCache {
             None => return false,
         };
 
-        let resource_uri = match tab.favicon_uri() {
-            Some(resource_uri) => resource_uri,
-            None => return false,
-        };
-
-        // Update favicon unless it was already loaded.
-        let changed = render_tab.favicon.as_ref().is_none_or(|f| f.resource_uri != resource_uri);
-        if changed {
-            render_tab.favicon = tab.favicon();
+        // Short-circuit if WebKit's favicon URI is unchanged.
+        #[cfg(feature = "webkit")]
+        if let Some(favicon) = render_tab.favicon.as_ref()
+            && let FaviconId::WebKit(uri) = &favicon.id
+            && tab.favicon_uri().as_ref() == Some(uri)
+        {
+            return false;
         }
 
-        changed
+        let was_none = render_tab.favicon.is_none();
+        render_tab.favicon = tab.favicon();
+
+        was_none && render_tab.favicon.is_none()
     }
 
     /// Cleanup unused textures.
@@ -1290,10 +1293,11 @@ impl TextureCache {
         }
 
         // Remove unused favicons textures from cache.
-        self.favicons.retain(|resource_uri, texture| {
-            let retain = self.tabs.values().any(|tab| {
-                tab.favicon.as_ref().is_some_and(|favicon| &favicon.resource_uri == resource_uri)
-            });
+        self.favicons.retain(|favicon_id, texture| {
+            let retain = self
+                .tabs
+                .values()
+                .any(|tab| tab.favicon.as_ref().is_some_and(|favicon| &favicon.id == favicon_id));
 
             // Release OpenGL texture.
             if !retain {
@@ -1329,16 +1333,16 @@ impl TextureCache {
     ) -> TabTextures<'a> {
         // Create favicon texture.
         if let Some(favicon) = tab.favicon.as_ref()
-            && !self.favicons.contains_key(&favicon.resource_uri)
+            && !self.favicons.contains_key(&favicon.id)
         {
             // Add favicon to texture cache.
             let texture = Texture::new_with_format(
                 &favicon.bytes,
                 favicon.width,
                 favicon.height,
-                gl::BGRA_EXT,
+                favicon.format,
             );
-            self.favicons.insert(favicon.resource_uri.clone(), texture);
+            self.favicons.insert(favicon.id.clone(), texture);
         }
 
         // Ignore tabs we already rendered.
@@ -1427,10 +1431,10 @@ impl<'a> TabTextures<'a> {
     /// Panics if the tab's main texture doesn't exist.
     fn new(
         tab: &'a Texture,
-        favicons: &'a HashMap<glib::GString, Texture>,
+        favicons: &'a HashMap<FaviconId, Texture>,
         render_tab: &'a RenderTab,
     ) -> Self {
-        let favicon = render_tab.favicon.as_ref().and_then(|f| favicons.get(&*f.resource_uri));
+        let favicon = render_tab.favicon.as_ref().and_then(|f| favicons.get(&f.id));
         Self { favicon, tab }
     }
 }
@@ -1465,7 +1469,7 @@ impl RenderTab {
     /// Get a borrowed texture cache key.
     fn key<'a>(&'a self) -> TabTextureCacheKey<'a> {
         TabTextureCacheKey {
-            favicon_uri: self.favicon.as_ref().map(|f| Cow::Borrowed(&f.resource_uri)),
+            favicon_id: self.favicon.as_ref().map(|f| Cow::Borrowed(&f.id)),
             label: Cow::Borrowed(self.label()),
             load_progress: self.load_progress,
             active: self.active,
@@ -1475,7 +1479,7 @@ impl RenderTab {
     /// Get an owned texture cache key.
     fn owned_key(&self) -> TabTextureCacheKey<'static> {
         TabTextureCacheKey {
-            favicon_uri: self.favicon.as_ref().map(|f| Cow::Owned(f.resource_uri.clone())),
+            favicon_id: self.favicon.as_ref().map(|f| Cow::Owned(f.id.clone())),
             label: Cow::Owned(self.label().to_string()),
             load_progress: self.load_progress,
             active: self.active,
@@ -1499,7 +1503,7 @@ impl Debug for RenderTab {
 /// Indexing key for the tab texture cache.
 #[derive(Hash, PartialEq, Eq, Debug)]
 struct TabTextureCacheKey<'a> {
-    favicon_uri: Option<Cow<'a, glib::GString>>,
+    favicon_id: Option<Cow<'a, FaviconId>>,
     label: Cow<'a, str>,
     load_progress: u8,
     active: bool,

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -58,7 +58,10 @@ impl Renderer {
 
     /// Perform drawing with this renderer.
     #[cfg_attr(feature = "profiling", profiling::function)]
-    pub fn draw<F: FnOnce(&Renderer)>(&mut self, size: Size, fun: F) {
+    pub fn draw<T, F>(&mut self, size: Size, fun: F) -> T
+    where
+        F: FnOnce(&Renderer) -> T,
+    {
         self.sized(size).make_current();
 
         // Resize OpenGL viewport.
@@ -66,11 +69,13 @@ impl Renderer {
         // This isn't done in `Self::resize` since the renderer must be current.
         unsafe { gl::Viewport(0, 0, size.width as i32, size.height as i32) };
 
-        fun(self);
+        let result = fun(self);
 
         unsafe { gl::Flush() };
 
         self.sized(size).swap_buffers();
+
+        result
     }
 
     /// Render texture at a position in viewport-coordinates.

--- a/src/wayland/protocols/mod.rs
+++ b/src/wayland/protocols/mod.rs
@@ -751,7 +751,10 @@ impl DmabufHandler for State {
         }
 
         // Update globally shared feedback.
-        self.engine_state.borrow_mut().dmabuf_feedback.replace(Some(feedback));
+        #[cfg(feature = "webkit")]
+        if let Some(webkit_state) = self.webkit_state.try_get().as_ref() {
+            webkit_state.dmabuf_feedback.replace(Some(feedback));
+        }
     }
 
     fn created(

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,12 +1,10 @@
 //! Browser window handling.
 
 use std::borrow::Cow;
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::mem;
 use std::ops::Range;
 use std::path::Path;
-use std::rc::Rc;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -14,6 +12,8 @@ use _text_input::zwp_text_input_v3::{ChangeCause, ContentHint, ContentPurpose, Z
 use funq::{MtQueueHandle, StQueueHandle};
 use glutin::display::Display;
 use indexmap::IndexMap;
+#[cfg(feature = "servo")]
+use servo::StringRequest;
 use smallvec::SmallVec;
 use smithay_client_toolkit::dmabuf::DmabufFeedback;
 use smithay_client_toolkit::reexports::client::protocol::wl_buffer::WlBuffer;
@@ -28,22 +28,40 @@ use smithay_client_toolkit::shell::WaylandSurface;
 use smithay_client_toolkit::shell::xdg::window::{
     Window as XdgWindow, WindowConfigure, WindowDecorations,
 };
+#[cfg(all(feature = "servo", feature = "webkit"))]
+use tracing::error;
 
 use crate::config::CONFIG;
-use crate::engine::{Engine, EngineId, Group, GroupId, NO_GROUP_ID, NO_GROUP_REF};
+use crate::engine::dummy::DummyEngine;
+#[cfg(feature = "servo")]
+use crate::engine::servo::ServoState;
+#[cfg(feature = "webkit")]
+use crate::engine::webkit::WebKitState;
+use crate::engine::{
+    Engine, EngineId, EngineType, Group, GroupId, NO_GROUP_ID, NO_GROUP_REF, OnDemandState,
+};
 use crate::storage::Storage;
+use crate::storage::engine_preference::EnginePreference;
 use crate::storage::groups::Groups;
 use crate::storage::history::{History, HistoryMatch, MAX_MATCHES};
 use crate::storage::session::{Session, SessionRecord};
 use crate::ui::engine_backdrop::EngineBackdrop;
 use crate::ui::overlay::Overlay;
-use crate::ui::overlay::downloads::{Download, DownloadId};
+#[cfg(feature = "webkit")]
+use crate::ui::overlay::downloads::Download;
+use crate::ui::overlay::downloads::DownloadId;
 use crate::ui::overlay::option_menu::{
     Borders, OptionMenuId, OptionMenuItem, OptionMenuPosition, ScrollTarget,
 };
 use crate::ui::{TOOLBAR_HEIGHT, Ui};
 use crate::wayland::protocols::ProtocolStates;
-use crate::{Position, Size, State, WebKitState};
+use crate::{Position, Size, State};
+
+/// Maximum number of surrounding bytes submitted to IME.
+///
+/// The value `4000` is chosen to match the maximum Wayland protocol message
+/// size, a higher value will lead to errors.
+pub const MAX_SURROUNDING_BYTES: usize = 4000;
 
 // Default window size.
 const DEFAULT_WIDTH: u32 = 360;
@@ -88,6 +106,11 @@ impl WindowHandler for State {
 
             // Cleanup unused groups.
             self.storage.groups.delete_orphans();
+
+            #[cfg(feature = "servo")]
+            if let Some(servo_state) = self.servo_state.try_get().as_mut() {
+                servo_state.on_window_close(window_id);
+            }
         }
     }
 
@@ -118,8 +141,14 @@ impl WindowHandler for State {
                 if window.active_tab == Some(engine_id) =>
             {
                 if let Some(engine) = window.active_tab_mut() {
-                    engine.paste(text);
+                    engine.commit_string(text);
                 }
+            },
+            #[cfg(feature = "servo")]
+            (KeyboardFocus::Browser, PasteTarget::Servo(engine_id, request))
+                if window.active_tab == Some(engine_id) =>
+            {
+                request.success(text);
             },
             // Ignore paste requests if input focus has changed.
             _ => (),
@@ -133,7 +162,11 @@ pub struct Window {
 
     tabs: IndexMap<EngineId, Box<dyn Engine>>,
     groups: IndexMap<GroupId, Group>,
-    engine_state: Rc<RefCell<WebKitState>>,
+    #[cfg(feature = "webkit")]
+    webkit_state: OnDemandState<WebKitState>,
+    #[cfg(feature = "servo")]
+    servo_state: OnDemandState<ServoState>,
+    engine_preference: EnginePreference,
     active_tab: Option<EngineId>,
 
     wayland_queue: QueueHandle<State>,
@@ -172,6 +205,7 @@ pub struct Window {
 }
 
 impl Window {
+    #[cfg_attr(all(feature = "servo", feature = "webkit"), expect(clippy::too_many_arguments))]
     pub fn new(
         protocol_states: &ProtocolStates,
         connection: Connection,
@@ -179,7 +213,8 @@ impl Window {
         queue: StQueueHandle<State>,
         wayland_queue: QueueHandle<State>,
         storage: &Storage,
-        engine_state: Rc<RefCell<WebKitState>>,
+        #[cfg(feature = "webkit")] webkit_state: OnDemandState<WebKitState>,
+        #[cfg(feature = "servo")] servo_state: OnDemandState<ServoState>,
     ) -> Self {
         let id = WindowId::new();
 
@@ -259,13 +294,17 @@ impl Window {
             engine_viewport,
             engine_surface,
             wayland_queue,
-            engine_state,
+            #[cfg(feature = "webkit")]
+            webkit_state,
+            #[cfg(feature = "servo")]
+            servo_state,
             connection,
             overlay,
             size,
             xdg,
             ui,
             id,
+            engine_preference: storage.engine_preference.clone(),
             active_tab: Some(EngineId::new(id, NO_GROUP_ID)),
             session_storage: storage.session.clone(),
             group_storage: storage.groups.clone(),
@@ -293,6 +332,11 @@ impl Window {
         self.id
     }
 
+    /// Check if the window has any tabs.
+    pub fn has_tabs(&self) -> bool {
+        !self.tabs.is_empty()
+    }
+
     /// Get a reference to a tab using its ID.
     #[allow(clippy::borrowed_box)]
     pub fn tab(&self, engine_id: EngineId) -> Option<&Box<dyn Engine>> {
@@ -300,6 +344,7 @@ impl Window {
     }
 
     /// Get a mutable reference to a tab using its ID.
+    #[inline]
     pub fn tab_mut(&mut self, engine_id: EngineId) -> Option<&mut Box<dyn Engine>> {
         self.tabs.get_mut(&engine_id)
     }
@@ -310,8 +355,9 @@ impl Window {
         focus_uribar: bool,
         switch_focus: bool,
         group_id: GroupId,
+        url: Option<&str>,
     ) -> EngineId {
-        self.add_tab_from_engine(focus_uribar, switch_focus, group_id, None)
+        self.add_tab_from_engine(focus_uribar, switch_focus, group_id, url, None)
     }
 
     /// Add a tab from an existing engine.
@@ -323,32 +369,50 @@ impl Window {
         focus_uribar: bool,
         switch_focus: bool,
         group_id: GroupId,
+        url: Option<&str>,
         engine_id: impl Into<Option<EngineId>>,
     ) -> EngineId {
         // Get the tab group for the new engine.
         let group = self.groups.get(&group_id).unwrap_or(NO_GROUP_REF);
 
+        // Get browser engine for this URL.
+        //
+        // If no URL is provided, we create a dummy engine. The dummy engine is replaced
+        // when a URL is loaded, at which point we can determine the preferred engine
+        // for the URL.
+        let engine_type = match url {
+            Some(url) => self.engine_preference.get(url).unwrap_or_else(|| {
+                let config = CONFIG.read().unwrap();
+                config.engine.default
+            }),
+            None => EngineType::Dummy,
+        };
+
         // Create a new browser engine.
         let new_engine_id = EngineId::new(self.id, group.id());
-        let engine = Box::new(self.engine_state.borrow_mut().create_engine(
-            new_engine_id,
-            self.engine_size(),
-            self.scale,
-        ));
+        let engine = match engine_type {
+            EngineType::Dummy => {
+                let surface = self.engine_surface.clone();
+                Box::new(DummyEngine::new(new_engine_id, surface))
+            },
+
+            #[cfg(feature = "webkit")]
+            EngineType::WebKit => self.create_webkit_engine(new_engine_id, url),
+            #[cfg(not(feature = "servo"))]
+            EngineType::Servo => self.create_webkit_engine(new_engine_id, url),
+
+            #[cfg(feature = "servo")]
+            EngineType::Servo => self.create_servo_engine(new_engine_id, url),
+            #[cfg(not(feature = "webkit"))]
+            EngineType::WebKit => self.create_servo_engine(new_engine_id, url),
+        };
 
         // Insert tab after the specified `engine_id`, or at the end.
         match engine_id.into().and_then(|id| self.tabs.get_index_of(&id)) {
             Some(index) if index + 1 < self.tabs.len() => {
                 self.tabs.insert_before(index + 1, new_engine_id, engine);
             },
-            _ => {
-                self.tabs.insert(new_engine_id, engine);
-            },
-        }
-
-        // Switch the active tab.
-        if switch_focus {
-            self.active_tab = Some(new_engine_id);
+            _ => _ = self.tabs.insert(new_engine_id, engine),
         }
 
         // Update tabs popup.
@@ -360,9 +424,9 @@ impl Window {
             self.ui.keyboard_focus_uribar();
         }
 
+        // Switch the active tab.
         if switch_focus {
-            self.ui.set_load_progress(1.);
-            self.ui.set_uri(String::new().into());
+            self.set_active_tab(new_engine_id);
         }
 
         self.unstall();
@@ -394,6 +458,9 @@ impl Window {
             self.set_active_tab(new_focus.map(|(engine_id, _)| *engine_id));
         }
 
+        // Ensure all associated option menus are closed.
+        self.overlay.close_engine_menus(engine_id);
+
         // Update tabs popup.
         self.overlay.tabs_mut().set_tabs(self.tabs.values(), self.active_tab);
 
@@ -404,6 +471,63 @@ impl Window {
         self.unstall();
     }
 
+    /// Reload a tab in a different browser engine.
+    ///
+    /// This uses the engine's current URI and automatically updates the engine
+    /// preference for its host.
+    #[cfg(all(feature = "servo", feature = "webkit"))]
+    pub fn switch_engine(&mut self, engine_id: EngineId, engine_type: EngineType) {
+        let uri = match self.tabs.get_mut(&engine_id) {
+            Some(engine) => engine.uri().to_string(),
+            None => return,
+        };
+
+        // Update engine preference.
+        self.engine_preference.set(&uri, engine_type);
+
+        // Swap out the tab's engine.
+        self.switch_engine_with_uri(engine_id, engine_type, &uri);
+
+        self.unstall();
+    }
+
+    /// Load a URI in an existing tab with a new browser engine.
+    fn switch_engine_with_uri(&mut self, engine_id: EngineId, engine_type: EngineType, uri: &str) {
+        // Just switch URI if the correct engine is already used.
+        if let Some(engine) = self.tabs.get_mut(&engine_id)
+            && engine.engine_type() == engine_type
+        {
+            engine.load_uri(uri);
+            return;
+        }
+
+        // Create a new engine with the desired engine type.
+        let new_engine = match engine_type {
+            #[cfg(feature = "webkit")]
+            EngineType::WebKit => self.create_webkit_engine(engine_id, Some(uri)),
+            #[cfg(not(feature = "servo"))]
+            EngineType::Servo => self.create_webkit_engine(engine_id, Some(uri)),
+
+            #[cfg(feature = "servo")]
+            EngineType::Servo => self.create_servo_engine(engine_id, Some(uri)),
+            #[cfg(not(feature = "webkit"))]
+            EngineType::WebKit => self.create_servo_engine(engine_id, Some(uri)),
+
+            EngineType::Dummy => unreachable!("switched to dummy engine"),
+        };
+
+        let old_engine = match self.tabs.get_mut(&engine_id) {
+            Some(engine) => engine,
+            None => return,
+        };
+
+        // Discard all existing option menus for the old engine.
+        self.overlay.close_engine_menus(engine_id);
+
+        // Replace the engine with a new one, using the requested URI.
+        *old_engine = new_engine;
+    }
+
     /// Get a reference to this window's active tab.
     #[allow(clippy::borrowed_box)]
     pub fn active_tab(&self) -> Option<&Box<dyn Engine>> {
@@ -411,18 +535,25 @@ impl Window {
     }
 
     /// Get a mutable reference to this window's active tab.
+    #[inline]
     pub fn active_tab_mut(&mut self) -> Option<&mut Box<dyn Engine>> {
         self.tab_mut(self.active_tab?)
     }
 
     /// Switch between tabs.
     pub fn set_active_tab(&mut self, engine_id: impl Into<Option<EngineId>>) {
+        // Indicate to the previous engine that it was hidden.
+        if let Some(engine) = self.active_tab_mut() {
+            engine.set_visible(false);
+        }
+
         self.active_tab = engine_id.into();
 
         // Update URI and load progress.
-        if let Some(engine) = self.active_tab.and_then(|id| self.tabs.get(&id)) {
+        if let Some(engine) = self.active_tab.and_then(|id| self.tabs.get_mut(&id)) {
             self.ui.set_uri(engine.uri());
             self.ui.set_load_progress(1.);
+            engine.set_visible(true);
         }
 
         // Update tabs popup.
@@ -455,6 +586,11 @@ impl Window {
 
     /// Load a URI with the active tab.
     pub fn load_uri(&mut self, uri: String, allow_relative_paths: bool) {
+        let active_tab = match self.active_tab {
+            Some(active_tab) => active_tab,
+            None => return,
+        };
+
         // Perform search if URI is not a recognized URI.
         let uri = match build_uri(uri.trim(), allow_relative_paths) {
             Some(uri) => uri,
@@ -464,8 +600,19 @@ impl Window {
             },
         };
 
-        if let Some(engine) = self.active_tab_mut() {
-            engine.load_uri(&uri);
+        // Switch browser engine if a URI with a different preference is loaded.
+        if let Some(engine_type) = self.engine_preference.get(&uri) {
+            self.switch_engine_with_uri(active_tab, engine_type, &uri);
+        } else {
+            let engine = self.active_tab_mut().unwrap();
+            match engine.engine_type() {
+                EngineType::Dummy => {
+                    let config = CONFIG.read().unwrap();
+                    let default_engine = config.engine.default;
+                    self.switch_engine_with_uri(active_tab, default_engine, &uri);
+                },
+                _ => engine.load_uri(&uri),
+            }
         }
 
         // Close open option menus.
@@ -578,16 +725,21 @@ impl Window {
         if !engine.dirty() && self.last_rendered_engine == Some(engine.id()) {
             return;
         }
+        self.last_rendered_engine = self.active_tab;
+        self.stalled = false;
 
-        // Attach the engine's buffer.
-        if !engine.attach_buffer(&self.engine_surface) {
-            self.engine_surface.attach(None, 0, 0);
-            self.engine_surface.commit();
-            return;
-        }
+        // Draw the engine's content.
+        let has_buffer = engine.draw();
 
         // Update the current page scale.
         self.ui.set_zoom_level(engine.zoom_level());
+
+        // Skip any other Wayland state changes without buffer attached.
+        if !has_buffer {
+            self.engine_surface.commit();
+            engine.frame_done();
+            return;
+        }
 
         // Update viewporter buffer transform.
 
@@ -603,7 +755,7 @@ impl Window {
         // Update opaque region.
         self.engine_surface.set_opaque_region(engine.opaque_region());
 
-        // Attach buffer with its damage since the last frame.
+        // Update damage since the last frame.
         match engine.take_buffer_damage() {
             Some(damage_rects) => {
                 for (x, y, width, height) in damage_rects {
@@ -612,13 +764,11 @@ impl Window {
             },
             None => self.engine_surface.damage(0, 0, dst_width, dst_height),
         }
+
         self.engine_surface.commit();
 
         // Request new engine frame.
         engine.frame_done();
-
-        self.last_rendered_engine = self.active_tab;
-        self.stalled = false;
     }
 
     /// Unstall the renderer.
@@ -787,6 +937,11 @@ impl Window {
 
             // Use real pointer events for the browser engine.
             if let Some(engine) = self.active_tab_mut() {
+                // Close all dropdowns when starting a new button press.
+                if down {
+                    engine.close_option_menu(None);
+                }
+
                 engine.pointer_button(time, position, button, down, modifiers);
             }
         } else {
@@ -1134,6 +1289,7 @@ impl Window {
     }
 
     /// Add a new download.
+    #[cfg(feature = "webkit")]
     pub fn add_download(&mut self, download: Download) {
         self.overlay.add_download(download);
 
@@ -1148,6 +1304,7 @@ impl Window {
     ///
     /// A progress value of `None` indicates that the download has failed and
     /// will not make any further progress.
+    #[cfg(feature = "webkit")]
     pub fn set_download_progress(&mut self, download_id: DownloadId, progress: Option<u8>) {
         self.overlay.set_download_progress(download_id, progress);
 
@@ -1505,6 +1662,7 @@ impl Window {
     }
 
     /// Open search UI for an engine.
+    #[cfg(feature = "webkit")]
     pub fn start_search(&mut self, engine_id: EngineId) {
         // Ignore request for background engines.
         if Some(engine_id) != self.active_tab {
@@ -1530,6 +1688,7 @@ impl Window {
     }
 
     /// Update the number of search matches.
+    #[cfg(feature = "webkit")]
     pub fn set_search_match_count(&mut self, engine_id: EngineId, count: usize) {
         // Ignore match count updates for inactive engines.
         if Some(engine_id) != self.active_tab {
@@ -1566,11 +1725,51 @@ impl Window {
     }
 
     /// Update an engine's audio playback state.
+    #[cfg(feature = "webkit")]
     pub fn set_audio_playing(&mut self, engine_id: EngineId, playing: bool) {
         self.overlay.tabs_mut().set_audio_playing(engine_id, playing);
 
         if self.overlay.dirty() {
             self.unstall();
+        }
+    }
+
+    /// Create a new WebKit browser engine.
+    #[cfg(feature = "webkit")]
+    fn create_webkit_engine(&self, engine_id: EngineId, uri: Option<&str>) -> Box<dyn Engine> {
+        let engine_size = self.engine_size();
+        Box::new(self.webkit_state.get().create_engine(
+            self.engine_surface.clone(),
+            engine_id,
+            engine_size,
+            self.scale,
+            uri,
+        ))
+    }
+
+    /// Create a new Servo browser engine.
+    #[cfg(feature = "servo")]
+    fn create_servo_engine(&self, engine_id: EngineId, uri: Option<&str>) -> Box<dyn Engine> {
+        let engine_size = self.engine_size();
+
+        let result = self.servo_state.get().create_engine(
+            &self.engine_surface,
+            engine_id,
+            engine_size,
+            self.scale,
+            uri,
+        );
+
+        match result {
+            Ok(engine) => Box::new(engine),
+            // Use WebKit as fallback if Servo engine cannot be created.
+            #[cfg(feature = "webkit")]
+            Err(err) => {
+                error!("Servo engine creation failed, falling back to WebKit: {err:?}");
+                self.create_webkit_engine(engine_id, uri)
+            },
+            #[cfg(not(feature = "webkit"))]
+            Err(err) => panic!("Failed to create Servo engine: {err:?}"),
         }
     }
 }
@@ -1600,8 +1799,8 @@ impl Default for WindowId {
 /// Keyboard focus surfaces.
 #[derive(PartialEq, Eq, Copy, Clone, Default, Debug)]
 pub enum KeyboardFocus {
-    None,
     #[default]
+    None,
     Ui,
     Overlay,
     Browser,
@@ -1746,8 +1945,9 @@ pub enum TextInputChange {
 }
 
 /// Target for a clipboard paste action.
-#[derive(Copy, Clone, Debug)]
 pub enum PasteTarget {
+    #[cfg(feature = "servo")]
+    Servo(EngineId, StringRequest),
     Browser(EngineId),
     Ui(WindowId),
 }
@@ -1756,6 +1956,8 @@ impl PasteTarget {
     /// Get the target window ID.
     pub fn window_id(&self) -> WindowId {
         match self {
+            #[cfg(feature = "servo")]
+            Self::Servo(engine_id, _) => engine_id.window_id(),
             Self::Browser(engine_id) => engine_id.window_id(),
             Self::Ui(window_id) => *window_id,
         }
@@ -1796,6 +1998,52 @@ impl From<TextMenuItem> for OptionMenuItem {
     fn from(item: TextMenuItem) -> Self {
         OptionMenuItem { label: item.label().into(), ..Default::default() }
     }
+}
+
+/// Clamp surrounding text to at most `max_len`.
+pub fn clamp_surrounding_text(
+    text: &str,
+    mut cursor_start: usize,
+    mut cursor_end: usize,
+    max_bytes: usize,
+) -> (String, i32, i32) {
+    // Ensure start/end are in the right order.
+    if cursor_start > cursor_end {
+        mem::swap(&mut cursor_start, &mut cursor_end);
+    }
+
+    // If the cursor range is longer than the maximum allowed bytes, we ignore the
+    // start and just return the bytes surrounding the end.
+    let original_cursor_start = cursor_start as i32;
+    if cursor_end - cursor_start > max_bytes {
+        cursor_start = cursor_end;
+    }
+
+    // Calculate available bytes outside the cursor range.
+    let max_bytes = max_bytes - (cursor_end - cursor_start);
+
+    // Get up to half of the available bytes after the cursor end.
+    let mut end = cursor_end + max_bytes / 2;
+    if end >= text.len() {
+        end = text.len();
+    } else {
+        while end > 0 && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+    };
+
+    // Get as many bytes as available before the cursor.
+    let remaining = max_bytes - (end - cursor_end);
+    let mut start = cursor_start.saturating_sub(remaining);
+    while start < text.len() && !text.is_char_boundary(start) {
+        start += 1;
+    }
+
+    // Calculate cursor indices relative to surrounding text.
+    let relative_start = original_cursor_start - start as i32;
+    let relative_end = cursor_end as i32 - start as i32;
+
+    (text[start..end].into(), relative_start, relative_end)
 }
 
 #[allow(rustdoc::bare_urls)]
@@ -1976,5 +2224,28 @@ mod tests {
         let expected = format!("file://{cwd}/src/main.rs");
         assert_eq!(build_uri("./src/main.rs", true).as_deref(), Some(expected.as_str()));
         assert_eq!(build_uri("src/main.rs", true).as_deref(), Some(expected.as_str()));
+    }
+
+    #[test]
+    fn surrounding_text() {
+        let (text, start, end) = clamp_surrounding_text("01234", 1, 4, 1);
+        assert_eq!(text, "3");
+        assert_eq!(start, -2);
+        assert_eq!(end, 1);
+
+        let (text, start, end) = clamp_surrounding_text("01234", 1, 4, 3);
+        assert_eq!(text, "123");
+        assert_eq!(start, 0);
+        assert_eq!(end, 3);
+
+        let (text, start, end) = clamp_surrounding_text("01234", 1, 4, 4);
+        assert_eq!(text, "0123");
+        assert_eq!(start, 1);
+        assert_eq!(end, 4);
+
+        let (text, start, end) = clamp_surrounding_text("01234", 1, 4, 99);
+        assert_eq!(text, "01234");
+        assert_eq!(start, 1);
+        assert_eq!(end, 4);
     }
 }

--- a/wpe-jsc-sys/src/lib.rs
+++ b/wpe-jsc-sys/src/lib.rs
@@ -19,12 +19,13 @@ use std::ffi::{
 
 #[allow(unused_imports)]
 use glib::{GType, gboolean, gconstpointer, gpointer};
+use glib_sys as glib;
+use gobject_sys as gobject;
 #[allow(unused_imports)]
 use libc::{FILE, intptr_t, off_t, size_t, ssize_t, time_t, uintptr_t};
 #[cfg(unix)]
 #[allow(unused_imports)]
 use libc::{dev_t, gid_t, pid_t, socklen_t, uid_t};
-use {glib_sys as glib, gobject_sys as gobject};
 
 // Enums
 pub type JSCCheckSyntaxMode = c_int;

--- a/wpe-platform-sys/src/lib.rs
+++ b/wpe-platform-sys/src/lib.rs
@@ -17,15 +17,18 @@ use std::ffi::{
     c_char, c_double, c_float, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_ushort, c_void,
 };
 
+use gio_sys as gio;
 #[allow(unused_imports)]
 use glib::{GType, gboolean, gconstpointer, gpointer};
+use glib_sys as glib;
+use gobject_sys as gobject;
 #[allow(unused_imports)]
 use libc::{FILE, intptr_t, off_t, size_t, ssize_t, time_t, uintptr_t};
 #[cfg(unix)]
 #[allow(unused_imports)]
 use libc::{dev_t, gid_t, pid_t, socklen_t, uid_t};
 use xkbcommon::{xkb_keymap, xkb_state};
-use {gio_sys as gio, glib_sys as glib, gobject_sys as gobject, xkbcommon_sys as xkbcommon};
+use xkbcommon_sys as xkbcommon;
 
 // Enums
 pub type WPEBufferDMABufFormatUsage = c_int;

--- a/wpe-webkit-sys/src/lib.rs
+++ b/wpe-webkit-sys/src/lib.rs
@@ -17,19 +17,21 @@ use std::ffi::{
     c_char, c_double, c_float, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_ushort, c_void,
 };
 
+use gio_sys as gio;
 #[allow(unused_imports)]
 use glib::{GType, gboolean, gconstpointer, gpointer};
+use glib_sys as glib;
+use gobject_sys as gobject;
 #[allow(unused_imports)]
 use libc::{FILE, intptr_t, off_t, size_t, ssize_t, time_t, uintptr_t};
 #[cfg(unix)]
 #[allow(unused_imports)]
 use libc::{dev_t, gid_t, pid_t, socklen_t, uid_t};
+use soup_sys as soup;
 use wpe::wpe_view_backend;
-use {
-    gio_sys as gio, glib_sys as glib, gobject_sys as gobject, soup_sys as soup,
-    wpe_java_script_core_sys as wpe_java_script_core, wpe_platform_sys as wpe_platform,
-    wpe_sys as wpe,
-};
+use wpe_java_script_core_sys as wpe_java_script_core;
+use wpe_platform_sys as wpe_platform;
+use wpe_sys as wpe;
 
 // Enums
 pub type WebKitAuthenticationScheme = c_int;


### PR DESCRIPTION
This patch adds support for using Servo as an alternative browser engine. Both Servo and WebKit are optional through their respective cargo features, making it possible to build either, or both.

Currently this still uses a forked version of Servo, due to upstream's lack of touch context menu support. However since two patches exist to address this, we'll hopefully be able to switch to upstream soon.

One large advantage of the Servo engine is that it allows trying out Kumo's UI without having to build the custom WebKit fork. It has also been significantly easier to contribute to Servo compared to WPE WebKit.

The browser engine can be changed by opening the context menu and selecting `Reload in WebKit/Servo`. To make using multiple engines simultaneously convenient, this choice is cached whenever selected and the next visit to the page will automatically load in the preferred engine.

The following features are not implemented in Servo yet:
 - Downloads
 - Page Search
 - Tab audio playback indicator